### PR TITLE
Allow incremental updates:

### DIFF
--- a/include/utils/json_config.h
+++ b/include/utils/json_config.h
@@ -120,8 +120,11 @@ class JSONLoaderConfig : public JSONConfigBase
     std::string m_vid_mapping_filename;
     //callset mapping file - if defined in upper level config file
     std::string m_callset_mapping_file;
-    //Limit callset row idx to this value
-    int64_t m_limit_callset_row_idx;
+    //max #rows - defining domain of the array
+    int64_t m_max_num_rows_in_array;
+    //Lower and upper bounds of callset row idx to import in this invocation
+    int64_t m_lb_callset_row_idx;
+    int64_t m_ub_callset_row_idx;
     //#VCF files to open/process in parallel
     int m_num_parallel_vcf_files;
     //do ping-pong buffering

--- a/include/utils/vid_mapper.h
+++ b/include/utils/vid_mapper.h
@@ -454,6 +454,8 @@ class VidMapper
     static std::unordered_map<std::string, int> m_length_descriptor_string_to_int;
     static std::unordered_map<std::string, std::type_index> m_typename_string_to_type_index;
     static std::unordered_map<std::string, int> m_typename_string_to_bcf_ht_type;
+    //Max #rows in the array - used to define domains
+    int64_t m_max_num_rows_in_array;
 };
 
 //Exceptions thrown 
@@ -487,10 +489,12 @@ class FileBasedVidMapper : public VidMapper
   public:
     FileBasedVidMapper() : VidMapper() { ; }
     FileBasedVidMapper(const std::string& filename, const std::string& callset_mapping_file="",
-        const int64_t limit_callset_row_idx=INT64_MAX, const bool callsets_file_required=true);
+        const int64_t max_num_rows_in_array=INT64_MAX, const int64_t lb_callset_row_idx=0, const int64_t ub_callset_row_idx=INT64_MAX,
+        const bool callsets_file_required=true);
   private:
     void parse_callsets_file(const std::string& filename);
-    int64_t m_limit_callset_row_idx;
+    int64_t m_lb_callset_row_idx;
+    int64_t m_ub_callset_row_idx;
 };
 
 #endif

--- a/src/loader/tiledb_loader.cc
+++ b/src/loader/tiledb_loader.cc
@@ -136,7 +136,7 @@ VCF2TileDBConverter::VCF2TileDBConverter(const std::string& config_filename, int
     VERIFY_OR_THROW(m_idx < m_num_converter_processes);
     //For standalone processes, must initialize VidMapper
     m_vid_mapper = static_cast<VidMapper*>(new FileBasedVidMapper(m_vid_mapping_filename, m_callset_mapping_file,
-          m_limit_callset_row_idx, true));
+          m_max_num_rows_in_array, m_lb_callset_row_idx, m_ub_callset_row_idx, true));
     m_vid_mapper->verify_file_partitioning();
     //2 entries sufficient
     resize_circular_buffers(2u);
@@ -418,7 +418,7 @@ VCF2TileDBLoader::VCF2TileDBLoader(const std::string& config_filename, int idx)
 #endif
   clear();
   m_vid_mapper = static_cast<VidMapper*>(new FileBasedVidMapper(m_vid_mapping_filename, m_callset_mapping_file,
-        m_limit_callset_row_idx, true));
+        m_max_num_rows_in_array, m_lb_callset_row_idx, m_ub_callset_row_idx, true));
   //partition files
   if(m_row_based_partitioning)
     m_vid_mapper->build_file_partitioning(idx, get_row_partition(idx));


### PR DESCRIPTION
* Define field called max_num_rows_in_array used to define TileDB array
schema domain
* Define fields called lb_callset_row_idx and ub_callset_row_idx to
specify rows for which data should be imported (ignoring other rows)