### PR TITLE
Produce combined gVCF in batches - output serialized into a buffer. This

### DIFF
--- a/include/genomicsdb/query_variants.h
+++ b/include/genomicsdb/query_variants.h
@@ -104,6 +104,29 @@ class GTProfileStats {
     uint64_t m_num_queries;
 };
 
+class VariantQueryProcessorScanState
+{
+  friend class VariantQueryProcessor;
+  public:
+    VariantQueryProcessorScanState()
+    {
+      m_iter = 0;
+      m_current_start_position = -1ll;
+      m_done = false;
+    }
+    VariantQueryProcessorScanState(VariantArrayCellIterator* iter, int64_t current_start_position)
+    {
+      m_iter = iter;
+      m_current_start_position = current_start_position;
+      m_done = false;
+    }
+    bool end() const { return m_done; }
+  private:
+    bool m_done;
+    VariantArrayCellIterator* m_iter;
+    int64_t m_current_start_position;
+};
+
 /*
  * Child class of QueryProcessor customized to handle variants
  */
@@ -145,7 +168,7 @@ class VariantQueryProcessor {
      */
     void scan_and_operate(const int ad, const VariantQueryConfig& query_config,
         SingleVariantOperatorBase& variant_operator,
-        unsigned column_interval_idx=0u, bool handle_spanning_deletions=false) const;
+        unsigned column_interval_idx=0u, bool handle_spanning_deletions=false, VariantQueryProcessorScanState* scan_state=0) const;
     /*
      * Deal with next cell in forward iteration in a scan
      * */

--- a/include/query_operations/broad_combined_gvcf.h
+++ b/include/query_operations/broad_combined_gvcf.h
@@ -60,6 +60,7 @@ class BroadCombinedGVCFOperator : public GA4GHOperator
     void clear();
     void switch_contig();
     virtual void operate(Variant& variant, const VariantQueryConfig& query_config);
+    inline bool overflow() const { return m_vcf_adapter->overflow(); }
     void handle_INFO_fields(const Variant& variant);
     void handle_FORMAT_fields(const Variant& variant);
     void handle_deletions(Variant& variant, const VariantQueryConfig& query_config);

--- a/include/query_operations/variant_operations.h
+++ b/include/query_operations/variant_operations.h
@@ -136,6 +136,11 @@ class SingleVariantOperatorBase
      * (b) Merged ALT allele list and updates the alleles LUT
      */
     virtual void operate(Variant& variant, const VariantQueryConfig& query_config);
+    /*
+     * Return true in child class if some output buffer used by the operator
+     * is full. Default implementation: return false
+     */
+    virtual bool overflow() const { return false; }
   protected:
     //Maintain mapping between alleles in input VariantCalls and merged allele list
     CombineAllelesLUT m_alleles_LUT;

--- a/include/utils/headers.h
+++ b/include/utils/headers.h
@@ -100,5 +100,18 @@ class CircularBufferController
     unsigned m_num_reserved_entries;
 };
 
+class RWBuffer
+{
+  public:
+    RWBuffer(size_t buffer_capacity=1048576u)
+    {
+      m_buffer.resize(buffer_capacity);
+      m_next_read_idx = 0u;
+      m_num_valid_bytes = 0u;
+    }
+    std::vector<uint8_t> m_buffer;
+    uint64_t m_next_read_idx;
+    size_t m_num_valid_bytes;
+};
 
 #endif

--- a/tests/run.py
+++ b/tests/run.py
@@ -115,10 +115,12 @@ def main():
                         "golden_outputs/t0_1_2_calls_at_0",
                         "golden_outputs/t0_1_2_variants_at_0",
                         "golden_outputs/t0_1_2_vcf_at_0",
+                        "golden_outputs/t0_1_2_vcf_at_0",
                     ] },
                     { "query_column_ranges" : [12150, 1000000000], "golden_output": [
                         "golden_outputs/t0_1_2_calls_at_12150",
                         "golden_outputs/t0_1_2_variants_at_12150",
+                        "golden_outputs/t0_1_2_vcf_at_12150",
                         "golden_outputs/t0_1_2_vcf_at_12150",
                         ] }
                     ]
@@ -129,10 +131,12 @@ def main():
                         "golden_outputs/t0_1_2_calls_at_0",
                         "golden_outputs/t0_1_2_variants_at_0",
                         "golden_outputs/t0_1_2_vcf_at_0",
+                        "golden_outputs/t0_1_2_vcf_at_0",
                     ] },
                     { "query_column_ranges" : [12150, 1000000000], "golden_output": [
                         "golden_outputs/t0_1_2_calls_at_12150",
                         "golden_outputs/t0_1_2_variants_at_12150",
+                        "golden_outputs/t0_1_2_vcf_at_12150",
                         "golden_outputs/t0_1_2_vcf_at_12150",
                         ] }
                     ]
@@ -144,10 +148,12 @@ def main():
                         "golden_outputs/t6_7_8_calls_at_0",
                         "golden_outputs/t6_7_8_variants_at_0",
                         "golden_outputs/t6_7_8_vcf_at_0",
+                        "golden_outputs/t6_7_8_vcf_at_0",
                     ] },
                     { "query_column_ranges" : [8029500, 1000000000], "golden_output": [
                         "golden_outputs/t6_7_8_calls_at_8029500",
                         "golden_outputs/t6_7_8_variants_at_8029500",
+                        "golden_outputs/t6_7_8_vcf_at_8029500",
                         "golden_outputs/t6_7_8_vcf_at_8029500",
                     ] }
                     ]
@@ -181,7 +187,7 @@ def main():
         if('query_params' in test_params_dict):
             for query_param_dict in test_params_dict['query_params']:
                 test_query_dict = create_query_json(ws_dir, test_name, query_param_dict["query_column_ranges"])
-                query_types_list = [ ('calls','--print-calls'), ('variants',''), ('vcf','--produce-Broad-GVCF') ]
+                query_types_list = [ ('calls','--print-calls'), ('variants',''), ('vcf','--produce-Broad-GVCF'), ('batched_vcf','--produce-Broad-GVCF -p 128') ]
                 idx = 0;
                 for query_type,cmd_line_param in query_types_list:
                     query_json_filename = tmpdir+os.path.sep+test_name+'_'+query_type+'.json'


### PR DESCRIPTION
can be used by other libraries (JNI, Spark etc)
Changes:
* VCFSerializedBufferAdapter that serializes bcf records into a buffer
* Support to break out of the loop in scan() and resume later using the
VCFSerializedBufferAdapter class.
* Example code to produce with batched VCF/BCF in gt_mpi_gather using
the paging parameter.