### PR TITLE
Workaround BCF2 limitations in htsjdk - bcf_str_missing is defined to be

### DIFF
--- a/include/query_operations/variant_operations.h
+++ b/include/query_operations/variant_operations.h
@@ -181,7 +181,8 @@ class VariantFieldHandlerBase
     virtual bool compute_valid_element_wise_sum(const Variant& variant, const VariantQueryConfig& query_config,
         unsigned query_idx, void* output_ptr, unsigned num_elements) = 0;
     virtual bool collect_and_extend_fields(const Variant& variant, const VariantQueryConfig& query_config, 
-        unsigned query_idx, const void ** output_ptr, unsigned& num_elements, const bool use_missing_values_only_not_vector_end=false) = 0;
+        unsigned query_idx, const void ** output_ptr, unsigned& num_elements,
+        const bool use_missing_values_only_not_vector_end=false, const bool use_vector_end_only=false) = 0;
 };
 
 //Big bag handler functions useful for handling different types of fields (int, char etc)
@@ -225,7 +226,8 @@ class VariantFieldHandler : public VariantFieldHandlerBase
      * Create an extended vector for use in BCF format fields, return result in output_ptr and num_elements
      */
     bool collect_and_extend_fields(const Variant& variant, const VariantQueryConfig& query_config, 
-        unsigned query_idx, const void ** output_ptr, unsigned& num_elements, const bool use_missing_values_only_not_vector_end=false);
+        unsigned query_idx, const void ** output_ptr, unsigned& num_elements,
+        const bool use_missing_values_only_not_vector_end=false, const bool use_vector_end_only=false);
   private:
     std::vector<uint64_t> m_num_calls_with_valid_data;
     DataType m_bcf_missing_value;

--- a/src/genomicsdb/variant_field_handler.cc
+++ b/src/genomicsdb/variant_field_handler.cc
@@ -262,7 +262,8 @@ bool VariantFieldHandler<DataType>::compute_valid_element_wise_sum(const Variant
 
 template<class DataType>
 bool VariantFieldHandler<DataType>::collect_and_extend_fields(const Variant& variant, const VariantQueryConfig& query_config, 
-        unsigned query_idx, const void ** output_ptr, unsigned& num_elements, const bool use_missing_values_only_not_vector_end)
+        unsigned query_idx, const void ** output_ptr, unsigned& num_elements,
+        const bool use_missing_values_only_not_vector_end, const bool use_vector_end_only)
 {
   auto max_elements_per_call = 0u;
   auto valid_idx = 0u;
@@ -301,7 +302,8 @@ bool VariantFieldHandler<DataType>::collect_and_extend_fields(const Variant& var
     }
     if(num_elements_inserted == 0u) //no elements inserted, insert missing value first
     {
-      m_extended_field_vector[extended_field_vector_idx] = get_bcf_missing_value<DataType>();
+      m_extended_field_vector[extended_field_vector_idx] = use_vector_end_only ? get_bcf_vector_end_value<DataType>()
+        : get_bcf_missing_value<DataType>();
       ++num_elements_inserted;
       ++extended_field_vector_idx;
     }


### PR DESCRIPTION
'\0' in htjdk, the standard uses it to represent vector end and 0x7 for
missing chars