### PR TITLE
Deal with overlapping variants

### DIFF
--- a/example/src/gt_mpi_gather.cc
+++ b/example/src/gt_mpi_gather.cc
@@ -413,6 +413,7 @@ int main(int argc, char *argv[]) {
   static struct option long_options[] = 
   {
     {"page-size",1,0,'p'},
+    {"rank",1,0,'r'},
     {"output-format",1,0,'O'},
     {"workspace",1,0,'w'},
     {"json-config",1,0,'j'},
@@ -436,13 +437,16 @@ int main(int argc, char *argv[]) {
   bool skip_query_on_root = false;
   unsigned command_idx = COMMAND_RANGE_QUERY;
   size_t segment_size = 10u*1024u*1024u; //in bytes = 10MB
-  while((c=getopt_long(argc, argv, "j:l:w:A:p:O:s:", long_options, NULL)) >= 0)
+  while((c=getopt_long(argc, argv, "j:l:w:A:p:O:s:r:", long_options, NULL)) >= 0)
   {
     switch(c)
     {
       case 'p':
         page_size = strtoull(optarg, 0, 10);
         std::cerr << "WARNING: page size is ignored except for scan now\n";
+        break;
+      case 'r':
+        my_world_mpi_rank = strtoull(optarg, 0, 10);
         break;
       case 'O':
         output_format = std::move(std::string(optarg));

--- a/example/src/vcf2tiledb.cc
+++ b/example/src/vcf2tiledb.cc
@@ -31,19 +31,32 @@
 
 int main(int argc, char** argv)
 {
+  //Initialize MPI environment
+  auto rc = MPI_Init(0, 0);
+  if (rc != MPI_SUCCESS) {
+    printf ("Error starting MPI program. Terminating.\n");
+    MPI_Abort(MPI_COMM_WORLD, rc);
+  }
+  //Get my world rank
+  int my_world_mpi_rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &my_world_mpi_rank);
   // Define long options
   static struct option long_options[] =
   {
     {"tmp-directory",1,0,'T'},
+    {"rank",1,0,'r'},
     {0,0,0,0},
   };
   int c;
-  while((c=getopt_long(argc, argv, "T:", long_options, NULL)) >= 0)
+  while((c=getopt_long(argc, argv, "T:r:", long_options, NULL)) >= 0)
   {
     switch(c)
     {
       case 'T':
         g_tmp_scratch_dir = optarg;
+        break;
+      case 'r':
+        my_world_mpi_rank = strtol(optarg, 0, 10);
         break;
       default:
         std::cerr << "Unknown parameter "<< argv[optind] << "\n";
@@ -55,18 +68,6 @@ int main(int argc, char** argv)
     std::cerr << "Needs <loader_json_config_file>\n";
     exit(-1);
   }
-  //Initialize MPI environment
-  auto rc = MPI_Init(0, 0);
-  if (rc != MPI_SUCCESS) {
-    printf ("Error starting MPI program. Terminating.\n");
-    MPI_Abort(MPI_COMM_WORLD, rc);
-  }
-  //Get number of MPI processes
-  int num_mpi_processes = 0;
-  MPI_Comm_size(MPI_COMM_WORLD, &num_mpi_processes);
-  //Get my world rank
-  int my_world_mpi_rank = 0;
-  MPI_Comm_rank(MPI_COMM_WORLD, &my_world_mpi_rank);
 #ifdef USE_GPERFTOOLS
   ProfilerStart("gprofile.log");
 #endif

--- a/src/utils/json_config.cc
+++ b/src/utils/json_config.cc
@@ -446,7 +446,7 @@ void JSONBasicQueryConfig::update_from_loader(JSONLoaderConfig* loader_config, c
     std::vector<ColumnRange> my_rank_queried_columns;
     for(auto queried_column : m_column_ranges[0])
     {
-      if (queried_column.first >= my_rank_loader_column_range.first && queried_column.first < my_rank_loader_column_range.second)
+      if(queried_column.second >= my_rank_loader_column_range.first && queried_column.first <= my_rank_loader_column_range.second)
         my_rank_queried_columns.emplace_back(queried_column);
     }
     m_column_ranges[0] = std::move(my_rank_queried_columns);


### PR DESCRIPTION
Fix for dealing with overlapping variants issue (described in https://github.com/Intel-HLS/GenomicsDB/wiki/Overlapping-variants-in-a-sample).
The workaround buffers cells which begin before or at the specified column partition boundary.
After the column partition boundary is crossed, all valid cells intersecting with
the column partition are operated on (written to TileDB array, combined
gVCF creations etc).

Minor bug fix also.