### PR TITLE
Print genomic co-ordinates in query JSON output

### DIFF
--- a/example/src/gt_mpi_gather.cc
+++ b/example/src/gt_mpi_gather.cc
@@ -337,7 +337,7 @@ void scan_and_produce_Broad_GVCF(const VariantQueryProcessor& qp, const VariantQ
 }
 #endif
 
-void print_calls(const VariantQueryProcessor& qp, const VariantQueryConfig& query_config, int command_idx)
+void print_calls(const VariantQueryProcessor& qp, const VariantQueryConfig& query_config, int command_idx, const VidMapper& id_mapper)
 {
   switch(command_idx)
   {
@@ -347,7 +347,7 @@ void print_calls(const VariantQueryProcessor& qp, const VariantQueryConfig& quer
         std::cout << "{\n";
         //variant_calls is an array of dictionaries
         std::cout << indent_prefix << "\"variant_calls\": [\n";
-        VariantCallPrintOperator printer(std::cout, indent_prefix+indent_prefix+indent_prefix+indent_prefix);
+        VariantCallPrintOperator printer(std::cout, indent_prefix+indent_prefix+indent_prefix+indent_prefix, &id_mapper);
         for(auto i=0ull;i<query_config.get_num_column_intervals();++i)
         {
           //Each dictionary contains 2 keys - query_interval and variant_calls
@@ -590,7 +590,7 @@ int main(int argc, char *argv[]) {
       break;
     case COMMAND_PRINT_CALLS:
     case COMMAND_PRINT_CSV:
-      print_calls(qp, query_config, command_idx);
+      print_calls(qp, query_config, command_idx, static_cast<const VidMapper&>(id_mapper));
       break;
   }
 #ifdef USE_GPERFTOOLS

--- a/include/genomicsdb/variant.h
+++ b/include/genomicsdb/variant.h
@@ -218,7 +218,7 @@ class VariantCall
       return static_cast<const VariantFieldTy*>(raw_ptr);
     }
     /** print **/
-    void print(std::ostream& stream, const VariantQueryConfig* query_config=0, const std::string& indent_prefix="") const;
+    void print(std::ostream& stream, const VariantQueryConfig* query_config=0, const std::string& indent_prefix="", const VidMapper* vid_mapper=0) const;
     /* 
      * Print JSON for Cotton
      */
@@ -453,7 +453,7 @@ class Variant
     /* Return query config */
     const VariantQueryConfig* get_query_config() const { return m_query_config; }
     /** print **/
-    void print(std::ostream& stream=std::cout, const VariantQueryConfig* query_config=0, const std::string& indent_prefix="") const;
+    void print(std::ostream& stream=std::cout, const VariantQueryConfig* query_config=0, const std::string& indent_prefix="", const VidMapper* vid_mapper=0) const;
     /*
      * Binary serialize into buffer
      */

--- a/include/query_operations/variant_operations.h
+++ b/include/query_operations/variant_operations.h
@@ -357,22 +357,24 @@ class ColumnHistogramOperator : public SingleCellOperatorBase
 class VariantCallPrintOperator : public SingleCellOperatorBase
 {
   public:
-    VariantCallPrintOperator(std::ostream& fptr=std::cout, const std::string& indent_prefix="")
+    VariantCallPrintOperator(std::ostream& fptr=std::cout, const std::string& indent_prefix="", const VidMapper* vid_mapper=0)
       : SingleCellOperatorBase(), m_fptr(&fptr), m_indent_prefix(indent_prefix)
       {
         m_num_calls_printed = 0ull;
+        m_vid_mapper = (vid_mapper && vid_mapper->is_initialized()) ? vid_mapper : 0;
       }
     virtual void operate(VariantCall& call, const VariantQueryConfig& query_config, const VariantArraySchema& schema)
     {
       if(m_num_calls_printed > 0ull)
         (*m_fptr) << ",\n";
-      call.print(*m_fptr, &query_config, m_indent_prefix);
+      call.print(*m_fptr, &query_config, m_indent_prefix, m_vid_mapper);
       ++m_num_calls_printed;
     }
   private:
     uint64_t m_num_calls_printed;
     std::string m_indent_prefix;
     std::ostream* m_fptr;
+    const VidMapper* m_vid_mapper;
 };
 
 //Dump CSV

--- a/tests/golden_outputs/t0_1_2_calls_at_0
+++ b/tests/golden_outputs/t0_1_2_calls_at_0
@@ -6,6 +6,7 @@
                 {
                     "row": 0,
                     "interval": [ 12140, 12294 ],
+                    "genomic_interval": { "1" : [ 12141, 12295 ] },
                     "fields": {
                         "REF": "C",
                         "ALT": [ "<NON_REF>" ],
@@ -19,6 +20,7 @@
                 {
                     "row": 1,
                     "interval": [ 12144, 12276 ],
+                    "genomic_interval": { "1" : [ 12145, 12277 ] },
                     "fields": {
                         "REF": "C",
                         "ALT": [ "<NON_REF>" ],
@@ -32,6 +34,7 @@
                 {
                     "row": 0,
                     "interval": [ 17384, 17384 ],
+                    "genomic_interval": { "1" : [ 17385, 17385 ] },
                     "fields": {
                         "REF": "G",
                         "ALT": [ "A","<NON_REF>" ],
@@ -55,6 +58,7 @@
                 {
                     "row": 1,
                     "interval": [ 17384, 17384 ],
+                    "genomic_interval": { "1" : [ 17385, 17385 ] },
                     "fields": {
                         "REF": "G",
                         "ALT": [ "T","<NON_REF>" ],
@@ -79,6 +83,7 @@
                 {
                     "row": 2,
                     "interval": [ 17384, 17384 ],
+                    "genomic_interval": { "1" : [ 17385, 17385 ] },
                     "fields": {
                         "REF": "G",
                         "ALT": [ "A","<NON_REF>" ],

--- a/tests/golden_outputs/t0_1_2_calls_at_12150
+++ b/tests/golden_outputs/t0_1_2_calls_at_12150
@@ -6,6 +6,7 @@
                 {
                     "row": 0,
                     "interval": [ 12140, 12294 ],
+                    "genomic_interval": { "1" : [ 12141, 12295 ] },
                     "fields": {
                         "REF": "C",
                         "ALT": [ "<NON_REF>" ],
@@ -19,6 +20,7 @@
                 {
                     "row": 1,
                     "interval": [ 12144, 12276 ],
+                    "genomic_interval": { "1" : [ 12145, 12277 ] },
                     "fields": {
                         "REF": "C",
                         "ALT": [ "<NON_REF>" ],
@@ -32,6 +34,7 @@
                 {
                     "row": 0,
                     "interval": [ 17384, 17384 ],
+                    "genomic_interval": { "1" : [ 17385, 17385 ] },
                     "fields": {
                         "REF": "G",
                         "ALT": [ "A","<NON_REF>" ],
@@ -55,6 +58,7 @@
                 {
                     "row": 1,
                     "interval": [ 17384, 17384 ],
+                    "genomic_interval": { "1" : [ 17385, 17385 ] },
                     "fields": {
                         "REF": "G",
                         "ALT": [ "T","<NON_REF>" ],
@@ -79,6 +83,7 @@
                 {
                     "row": 2,
                     "interval": [ 17384, 17384 ],
+                    "genomic_interval": { "1" : [ 17385, 17385 ] },
                     "fields": {
                         "REF": "G",
                         "ALT": [ "A","<NON_REF>" ],

--- a/tests/golden_outputs/t0_1_2_variants_at_0
+++ b/tests/golden_outputs/t0_1_2_variants_at_0
@@ -2,6 +2,7 @@
     "variants": [
         {
             "interval": [ 12140, 12294 ],
+            "genomic_interval": { "1" : [ 12141, 12295 ] },
              "common_fields" : {
 
             },
@@ -9,6 +10,7 @@
                 {
                     "row": 0,
                     "interval": [ 12140, 12294 ],
+                    "genomic_interval": { "1" : [ 12141, 12295 ] },
                     "fields": {
                         "REF": "C",
                         "ALT": [ "<NON_REF>" ],
@@ -23,6 +25,7 @@
         },
         {
             "interval": [ 12144, 12276 ],
+            "genomic_interval": { "1" : [ 12145, 12277 ] },
              "common_fields" : {
 
             },
@@ -30,6 +33,7 @@
                 {
                     "row": 1,
                     "interval": [ 12144, 12276 ],
+                    "genomic_interval": { "1" : [ 12145, 12277 ] },
                     "fields": {
                         "REF": "C",
                         "ALT": [ "<NON_REF>" ],
@@ -44,6 +48,7 @@
         },
         {
             "interval": [ 17384, 17384 ],
+            "genomic_interval": { "1" : [ 17385, 17385 ] },
              "common_fields" : {
                 "REF": "G",
                 "ALT": [ "A","<NON_REF>" ]
@@ -52,6 +57,7 @@
                 {
                     "row": 0,
                     "interval": [ 17384, 17384 ],
+                    "genomic_interval": { "1" : [ 17385, 17385 ] },
                     "fields": {
                         "REF": "G",
                         "ALT": [ "A","<NON_REF>" ],
@@ -75,6 +81,7 @@
                 {
                     "row": 2,
                     "interval": [ 17384, 17384 ],
+                    "genomic_interval": { "1" : [ 17385, 17385 ] },
                     "fields": {
                         "REF": "G",
                         "ALT": [ "A","<NON_REF>" ],
@@ -97,6 +104,7 @@
         },
         {
             "interval": [ 17384, 17384 ],
+            "genomic_interval": { "1" : [ 17385, 17385 ] },
              "common_fields" : {
 
             },
@@ -104,6 +112,7 @@
                 {
                     "row": 1,
                     "interval": [ 17384, 17384 ],
+                    "genomic_interval": { "1" : [ 17385, 17385 ] },
                     "fields": {
                         "REF": "G",
                         "ALT": [ "T","<NON_REF>" ],

--- a/tests/golden_outputs/t0_1_2_variants_at_12150
+++ b/tests/golden_outputs/t0_1_2_variants_at_12150
@@ -2,6 +2,7 @@
     "variants": [
         {
             "interval": [ 12140, 12294 ],
+            "genomic_interval": { "1" : [ 12141, 12295 ] },
              "common_fields" : {
 
             },
@@ -9,6 +10,7 @@
                 {
                     "row": 0,
                     "interval": [ 12140, 12294 ],
+                    "genomic_interval": { "1" : [ 12141, 12295 ] },
                     "fields": {
                         "REF": "C",
                         "ALT": [ "<NON_REF>" ],
@@ -23,6 +25,7 @@
         },
         {
             "interval": [ 12144, 12276 ],
+            "genomic_interval": { "1" : [ 12145, 12277 ] },
              "common_fields" : {
 
             },
@@ -30,6 +33,7 @@
                 {
                     "row": 1,
                     "interval": [ 12144, 12276 ],
+                    "genomic_interval": { "1" : [ 12145, 12277 ] },
                     "fields": {
                         "REF": "C",
                         "ALT": [ "<NON_REF>" ],
@@ -44,6 +48,7 @@
         },
         {
             "interval": [ 17384, 17384 ],
+            "genomic_interval": { "1" : [ 17385, 17385 ] },
              "common_fields" : {
                 "REF": "G",
                 "ALT": [ "A","<NON_REF>" ]
@@ -52,6 +57,7 @@
                 {
                     "row": 0,
                     "interval": [ 17384, 17384 ],
+                    "genomic_interval": { "1" : [ 17385, 17385 ] },
                     "fields": {
                         "REF": "G",
                         "ALT": [ "A","<NON_REF>" ],
@@ -75,6 +81,7 @@
                 {
                     "row": 2,
                     "interval": [ 17384, 17384 ],
+                    "genomic_interval": { "1" : [ 17385, 17385 ] },
                     "fields": {
                         "REF": "G",
                         "ALT": [ "A","<NON_REF>" ],
@@ -97,6 +104,7 @@
         },
         {
             "interval": [ 17384, 17384 ],
+            "genomic_interval": { "1" : [ 17385, 17385 ] },
              "common_fields" : {
 
             },
@@ -104,6 +112,7 @@
                 {
                     "row": 1,
                     "interval": [ 17384, 17384 ],
+                    "genomic_interval": { "1" : [ 17385, 17385 ] },
                     "fields": {
                         "REF": "G",
                         "ALT": [ "T","<NON_REF>" ],

--- a/tests/golden_outputs/t6_7_8_calls_at_0
+++ b/tests/golden_outputs/t6_7_8_calls_at_0
@@ -6,6 +6,7 @@
                 {
                     "row": 0,
                     "interval": [ 8029499, 8029501 ],
+                    "genomic_interval": { "1" : [ 8029500, 8029502 ] },
                     "fields": {
                         "REF": "TGG",
                         "ALT": [ "T","<NON_REF>" ],
@@ -26,6 +27,7 @@
                 {
                     "row": 1,
                     "interval": [ 8029499, 8029501 ],
+                    "genomic_interval": { "1" : [ 8029500, 8029502 ] },
                     "fields": {
                         "REF": "TGG",
                         "ALT": [ "T","TG","<NON_REF>" ],
@@ -47,6 +49,7 @@
                 {
                     "row": 2,
                     "interval": [ 8029499, 8029500 ],
+                    "genomic_interval": { "1" : [ 8029500, 8029501 ] },
                     "fields": {
                         "REF": "TG",
                         "ALT": [ "T","<NON_REF>" ],

--- a/tests/golden_outputs/t6_7_8_calls_at_8029500
+++ b/tests/golden_outputs/t6_7_8_calls_at_8029500
@@ -6,6 +6,7 @@
                 {
                     "row": 0,
                     "interval": [ 8029499, 8029501 ],
+                    "genomic_interval": { "1" : [ 8029500, 8029502 ] },
                     "fields": {
                         "REF": "TGG",
                         "ALT": [ "T","<NON_REF>" ],
@@ -26,6 +27,7 @@
                 {
                     "row": 1,
                     "interval": [ 8029499, 8029501 ],
+                    "genomic_interval": { "1" : [ 8029500, 8029502 ] },
                     "fields": {
                         "REF": "TGG",
                         "ALT": [ "T","TG","<NON_REF>" ],
@@ -47,6 +49,7 @@
                 {
                     "row": 2,
                     "interval": [ 8029499, 8029500 ],
+                    "genomic_interval": { "1" : [ 8029500, 8029501 ] },
                     "fields": {
                         "REF": "TG",
                         "ALT": [ "T","<NON_REF>" ],

--- a/tests/golden_outputs/t6_7_8_variants_at_0
+++ b/tests/golden_outputs/t6_7_8_variants_at_0
@@ -2,6 +2,7 @@
     "variants": [
         {
             "interval": [ 8029499, 8029501 ],
+            "genomic_interval": { "1" : [ 8029500, 8029502 ] },
              "common_fields" : {
 
             },
@@ -9,6 +10,7 @@
                 {
                     "row": 0,
                     "interval": [ 8029499, 8029501 ],
+                    "genomic_interval": { "1" : [ 8029500, 8029502 ] },
                     "fields": {
                         "REF": "TGG",
                         "ALT": [ "T","<NON_REF>" ],
@@ -30,6 +32,7 @@
         },
         {
             "interval": [ 8029499, 8029501 ],
+            "genomic_interval": { "1" : [ 8029500, 8029502 ] },
              "common_fields" : {
 
             },
@@ -37,6 +40,7 @@
                 {
                     "row": 1,
                     "interval": [ 8029499, 8029501 ],
+                    "genomic_interval": { "1" : [ 8029500, 8029502 ] },
                     "fields": {
                         "REF": "TGG",
                         "ALT": [ "T","TG","<NON_REF>" ],
@@ -59,6 +63,7 @@
         },
         {
             "interval": [ 8029499, 8029500 ],
+            "genomic_interval": { "1" : [ 8029500, 8029501 ] },
              "common_fields" : {
 
             },
@@ -66,6 +71,7 @@
                 {
                     "row": 2,
                     "interval": [ 8029499, 8029500 ],
+                    "genomic_interval": { "1" : [ 8029500, 8029501 ] },
                     "fields": {
                         "REF": "TG",
                         "ALT": [ "T","<NON_REF>" ],

--- a/tests/golden_outputs/t6_7_8_variants_at_8029500
+++ b/tests/golden_outputs/t6_7_8_variants_at_8029500
@@ -2,6 +2,7 @@
     "variants": [
         {
             "interval": [ 8029499, 8029501 ],
+            "genomic_interval": { "1" : [ 8029500, 8029502 ] },
              "common_fields" : {
 
             },
@@ -9,6 +10,7 @@
                 {
                     "row": 0,
                     "interval": [ 8029499, 8029501 ],
+                    "genomic_interval": { "1" : [ 8029500, 8029502 ] },
                     "fields": {
                         "REF": "TGG",
                         "ALT": [ "T","<NON_REF>" ],
@@ -30,6 +32,7 @@
         },
         {
             "interval": [ 8029499, 8029501 ],
+            "genomic_interval": { "1" : [ 8029500, 8029502 ] },
              "common_fields" : {
 
             },
@@ -37,6 +40,7 @@
                 {
                     "row": 1,
                     "interval": [ 8029499, 8029501 ],
+                    "genomic_interval": { "1" : [ 8029500, 8029502 ] },
                     "fields": {
                         "REF": "TGG",
                         "ALT": [ "T","TG","<NON_REF>" ],
@@ -59,6 +63,7 @@
         },
         {
             "interval": [ 8029499, 8029500 ],
+            "genomic_interval": { "1" : [ 8029500, 8029501 ] },
              "common_fields" : {
 
             },
@@ -66,6 +71,7 @@
                 {
                     "row": 2,
                     "interval": [ 8029499, 8029500 ],
+                    "genomic_interval": { "1" : [ 8029500, 8029501 ] },
                     "fields": {
                         "REF": "TG",
                         "ALT": [ "T","<NON_REF>" ],


### PR DESCRIPTION
Print genomic co-ordinates (if possible) in JSON for variants and variant calls.

NOTE: TileDB columns are 0-based while genomic co-ordinates are 1-based.