### PR TITLE
VCF split

### DIFF
--- a/example/src/vcf2tiledb.cc
+++ b/example/src/vcf2tiledb.cc
@@ -29,6 +29,15 @@
 #include "gperftools/profiler.h"
 #endif
 
+enum VCF2TileDBArgsEnum
+{
+  VCF2TILEDB_ARG_SPLIT_FILES_IDX=1000,
+  VCF2TILEDB_ARG_SPLIT_FILES_PRODUCE_ALL_PARTITIONS_IDX,
+  VCF2TILEDB_ARG_SPLIT_FILES_RESULTS_DIRECTORY_IDX,
+  VCF2TILEDB_ARG_SPLIT_FILES_SPLIT_OUTPUT_FILENAME_IDX,
+  VCF2TILEDB_ARG_SPLIT_FILES_SPLIT_CALLSET_MAPPING_IDX
+};
+
 int main(int argc, char** argv)
 {
   //Initialize MPI environment
@@ -45,9 +54,19 @@ int main(int argc, char** argv)
   {
     {"tmp-directory",1,0,'T'},
     {"rank",1,0,'r'},
+    {"split-files",0,0,VCF2TILEDB_ARG_SPLIT_FILES_IDX},
+    {"split-all-partitions",0,0,VCF2TILEDB_ARG_SPLIT_FILES_PRODUCE_ALL_PARTITIONS_IDX},
+    {"split-files-results-directory",1,0,VCF2TILEDB_ARG_SPLIT_FILES_RESULTS_DIRECTORY_IDX},
+    {"split-output-filename",1,0,VCF2TILEDB_ARG_SPLIT_FILES_SPLIT_OUTPUT_FILENAME_IDX},
+    {"split-callset-mapping-file",0,0,VCF2TILEDB_ARG_SPLIT_FILES_SPLIT_CALLSET_MAPPING_IDX},
     {0,0,0,0},
   };
   int c;
+  auto split_files = false;
+  auto produce_all_partitions = false;
+  std::string results_directory;
+  std::string split_output_filename;
+  auto split_callset_mapping_file = false;
   while((c=getopt_long(argc, argv, "T:r:", long_options, NULL)) >= 0)
   {
     switch(c)
@@ -57,6 +76,21 @@ int main(int argc, char** argv)
         break;
       case 'r':
         my_world_mpi_rank = strtol(optarg, 0, 10);
+        break;
+      case VCF2TILEDB_ARG_SPLIT_FILES_IDX:
+        split_files = true;
+        break;
+      case VCF2TILEDB_ARG_SPLIT_FILES_PRODUCE_ALL_PARTITIONS_IDX:
+        produce_all_partitions = true;
+        break;
+      case VCF2TILEDB_ARG_SPLIT_FILES_RESULTS_DIRECTORY_IDX:
+        results_directory = optarg;
+        break;
+      case VCF2TILEDB_ARG_SPLIT_FILES_SPLIT_OUTPUT_FILENAME_IDX:
+        split_output_filename = optarg;
+        break;
+      case VCF2TILEDB_ARG_SPLIT_FILES_SPLIT_CALLSET_MAPPING_IDX:
+        split_callset_mapping_file = true;
         break;
       default:
         std::cerr << "Unknown parameter "<< argv[optind] << "\n";
@@ -68,14 +102,52 @@ int main(int argc, char** argv)
     std::cerr << "Needs <loader_json_config_file>\n";
     exit(-1);
   }
+  auto loader_json_config_file = std::move(std::string(argv[optind]));
 #ifdef USE_GPERFTOOLS
   ProfilerStart("gprofile.log");
 #endif
-  //Loader object
-  VCF2TileDBLoader loader(argv[optind], my_world_mpi_rank);
+  //Split files as per the partitions defined - don't load data
+  if(split_files)
+  {
+    JSONLoaderConfig loader_config;
+    FileBasedVidMapper id_mapper;
+    loader_config.read_from_file(loader_json_config_file, &id_mapper, my_world_mpi_rank);
+    if(loader_config.is_partitioned_by_row())
+    {
+      std::cerr << "Splitting is available for column partitioning, row partitioning should be trivial if samples are scattered across files. See wiki page https://github.com/Intel-HLS/GenomicsDB/wiki/Dealing-with-multiple-GenomicsDB-partitions for more information\n";
+      return 0;
+    }
+    //Might specify more VCF files from the command line
+    for(auto i=optind+1;i<argc;++i)
+      id_mapper.get_or_append_global_file_idx(argv[i]);
+    //Single split output
+    if(!produce_all_partitions && id_mapper.get_num_files() == 1u && !split_output_filename.empty())
+      id_mapper.set_single_split_file_path(0u, split_output_filename);
+    std::vector<std::vector<uint8_t>> empty_buffers;
+    std::vector<LoaderConverterMessageExchange> empty_exchange;
+    const auto& column_partitions = loader_config.get_sorted_column_partitions();
+    auto loop_bound = (produce_all_partitions ? column_partitions.size() : 1u);
+    for(auto i=0ull;i<loop_bound;++i)
+    {
+      int rank = produce_all_partitions ? i : my_world_mpi_rank;
+      VCF2TileDBConverter converter(loader_json_config_file, rank,
+          static_cast<VidMapper*>(&id_mapper), &empty_buffers, &empty_exchange);
+      converter.print_all_partitions(results_directory, "", rank);
+      if(split_callset_mapping_file)
+        id_mapper.write_partition_callsets_json_file(loader_config.get_callset_mapping_filename(), results_directory, rank);
+    }
+    if(split_callset_mapping_file)
+      id_mapper.write_partition_loader_json_file(loader_json_config_file, loader_config.get_callset_mapping_filename(),
+          results_directory, (produce_all_partitions ? column_partitions.size() : 1u), my_world_mpi_rank);
+  }
+  else
+  {
+    //Loader object
+    VCF2TileDBLoader loader(loader_json_config_file, my_world_mpi_rank);
 #ifdef HTSDIR
-  loader.read_all();
+    loader.read_all();
 #endif
+  }
 #ifdef USE_GPERFTOOLS
   ProfilerStop();
 #endif

--- a/include/loader/tiledb_loader.h
+++ b/include/loader/tiledb_loader.h
@@ -163,6 +163,11 @@ class VCF2TileDBConverter : public VCF2TileDBLoaderConverterBase
      * Write to buffer stream
      */
     void write_data_to_buffer_stream(const int64_t buffer_stream_idx, const unsigned partition_idx, const uint8_t* data, const size_t num_bytes);
+    //Print partitions of files - useful when splitting files into partitions
+    /*
+     * Print all included partitions
+     */
+    void print_all_partitions(const std::string& results_directory, const std::string& output_type, const int rank);
   private:
     void clear();
     void initialize_column_batch_objects();

--- a/include/loader/tiledb_loader_file_base.h
+++ b/include/loader/tiledb_loader_file_base.h
@@ -145,6 +145,7 @@ class File2TileDBBinaryColumnPartitionBase
       m_last_full_line_end_buffer_offset_for_local_callset.clear();
       m_buffer_offset_for_local_callset.clear();
       m_buffer_full_for_local_callset.clear();
+      m_split_filename.clear();
     }
     //Delete copy constructor
     File2TileDBBinaryColumnPartitionBase(const File2TileDBBinaryColumnPartitionBase& other) = delete;
@@ -195,6 +196,8 @@ class File2TileDBBinaryColumnPartitionBase
     //Pointer to buffer
     std::vector<uint8_t>* m_buffer_ptr;
     GenomicsDBImportReaderBase* m_base_reader_ptr;
+    //Split file name for this partition
+    std::string m_split_filename;
 };
 
 //Buffer stream idx, partition idx
@@ -298,6 +301,43 @@ class File2TileDBBinaryBase
      * Return #callsets in current record
      */
     virtual uint64_t get_num_callsets_in_record(const File2TileDBBinaryColumnPartitionBase& partition_info) const = 0;
+    //Print partitions of the file - useful when splitting files into partitions
+    /*
+     * Print all included partitions
+     */
+    void print_all_partitions(const std::string& results_directory, const std::string& output_type, const int rank, const bool close_file);
+    /*
+     * Print data for partition
+     */
+    void print_partition(File2TileDBBinaryColumnPartitionBase& partition_info,
+        const std::string& results_directory, const std::string& output_type,
+        const unsigned partition_idx, const bool close_file);
+    /*
+     * Opens the file for partition - useful when printing data for a specific partition (splitting files)
+     * Must be implemented by sub-classes
+     */
+    virtual bool open_partition_output_file(const std::string& results_directory, std::string& output_filename,
+        const std::string& output_type, File2TileDBBinaryColumnPartitionBase& partition_info, const unsigned partition_idx)
+    {
+      throw File2TileDBBinaryException("Unimplemented operation");
+      return false;
+    }
+    /*
+     * Prints data of the partition
+     * Must be implemented by sub-classes
+     */
+    virtual void write_partition_data(File2TileDBBinaryColumnPartitionBase& partition_info)
+    {
+      throw File2TileDBBinaryException("Unimplemented operation");
+    }
+    /*
+     * Closes the file for partition - useful when printing data for a specific partition (splitting files)
+     * Must be implemented by sub-classes
+     */
+    virtual void close_partition_output_file(File2TileDBBinaryColumnPartitionBase& partition_info)
+    {
+      throw File2TileDBBinaryException("Unimplemented operation");
+    }
   protected:
     inline int64_t get_enabled_idx_for_local_callset_idx(int64_t local_callset_idx) const
     {

--- a/src/loader/tiledb_loader.cc
+++ b/src/loader/tiledb_loader.cc
@@ -449,6 +449,14 @@ void VCF2TileDBConverter::create_and_print_histogram(const std::string& config_f
   combined_histogram->print(fptr);
   delete combined_histogram;
 }
+
+void VCF2TileDBConverter::print_all_partitions(const std::string& results_directory, const std::string& output_type, const int rank)
+{
+#pragma omp parallel for default(shared) num_threads(m_num_parallel_vcf_files)
+  for(auto i=0u;i<m_file2binary_handlers.size();++i)
+    m_file2binary_handlers[i]->print_all_partitions(results_directory, output_type, rank, true);
+}
+
 #endif //ifdef HTSLIB
 
 //Loader functions


### PR DESCRIPTION
* vcf2tiledb can now split input files based on column partitions specified. Options are available to create callset mapping and loader
JSONs for the partitions also
* Split file details are stored in File2TileDBBinaryColumnPartitionBase
and its subclasses
* Wrapper functions for writing split files in File2TileDBBase and
VCF2TileDBConverter
* FileBasedVidMapper does the heavy lifting of creating JSON files for
the partitioned data
* Slight re-org of JSON classes