### PR TITLE
Provide timers in loader and query

### DIFF
--- a/include/genomicsdb/variant_storage_manager.h
+++ b/include/genomicsdb/variant_storage_manager.h
@@ -51,11 +51,9 @@ class VariantArrayCellIterator
       if(m_tiledb_array_iterator)
         tiledb_array_iterator_finalize(m_tiledb_array_iterator);
       m_tiledb_array_iterator = 0;
-#ifdef DEBUG
-      std::cerr << "#cells traversed "<<m_num_cells_iterated_over<<"\n";
-#endif
 #ifdef DO_PROFILING
-      m_tiledb_timer.print_cumulative("TileDB iterator", std::cerr);
+      m_tiledb_timer.print("TileDB iterator", std::cerr);
+      m_tiledb_to_buffer_cell_timer.print("TileDB to buffer cell", std::cerr);
 #endif
     }
     //Delete copy and move constructors
@@ -114,6 +112,7 @@ class VariantArrayCellIterator
 #endif
 #ifdef DO_PROFILING
     Timer m_tiledb_timer;
+    Timer m_tiledb_to_buffer_cell_timer;
 #endif
 };
 

--- a/include/loader/tiledb_loader.h
+++ b/include/loader/tiledb_loader.h
@@ -236,6 +236,11 @@ class VCF2TileDBLoaderReadState
       m_exchange_counter = num_exchanges-1u;
       m_num_parallel_omp_sections = 1 + (do_ping_pong_buffering ? 1 : 0) +
         (offload_vcf_output_processing && do_ping_pong_buffering ? 1 : 0);
+      m_timer_vec = std::move(std::vector<Timer*>({
+            &m_fetch_timer,
+            &m_load_timer,
+            &m_flush_output_timer
+            }));
     }
     bool is_done() const { return m_done; }
   private:
@@ -245,6 +250,10 @@ class VCF2TileDBLoaderReadState
     Timer m_fetch_timer;
     Timer m_load_timer;
     Timer m_flush_output_timer;
+    Timer m_single_thread_phase_timer;
+    Timer m_time_in_read_all;
+    Timer m_sections_timer;
+    std::vector<Timer*> m_timer_vec; //for critical path
     int m_num_parallel_omp_sections;
 };
 

--- a/include/query_operations/broad_combined_gvcf.h
+++ b/include/query_operations/broad_combined_gvcf.h
@@ -28,6 +28,7 @@
 #include "variant_operations.h"
 #include "vcf_adapter.h"
 #include "vid_mapper.h"
+#include "timer.h"
 
 //known_field_enum, query_idx, VariantFieldTypeEnum, bcf_ht_type, vcf field name, INFO_field_combine_operation
 typedef std::tuple<unsigned, unsigned, VariantFieldTypeEnum, unsigned, std::string, int> INFO_tuple_type;
@@ -60,6 +61,9 @@ class BroadCombinedGVCFOperator : public GA4GHOperator
     {
       bcf_destroy(m_bcf_out);
       clear();
+#ifdef DO_PROFILING
+      m_bcf_t_creation_timer.print("bcf_t creation time", std::cerr);
+#endif
     }
     void clear();
     void switch_contig();
@@ -104,6 +108,8 @@ class BroadCombinedGVCFOperator : public GA4GHOperator
     std::vector<int> m_spanning_deletion_remapped_GT;
     //Allowed bases
     static const std::unordered_set<char> m_legal_bases;
+    //For profiling
+    Timer m_bcf_t_creation_timer;
 };
 
 #endif //ifdef HTSDIR

--- a/include/utils/timer.h
+++ b/include/utils/timer.h
@@ -75,21 +75,31 @@ class Timer
       m_cumulative_cpu_time += m_last_interval_cpu_time;
       m_cumulative_wall_clock_time += m_last_interval_wall_clock_time;
     }
-    void print(const std::string& prefix="", std::ostream& fptr = std::cout) const
+    void print_last_interval(const std::string& prefix="", std::ostream& fptr = std::cout) const
     {
-      if(prefix.size() > 0u)
-        fptr << prefix <<" : ";
-      fptr << "Wall-clock time(s) : "<< std::setprecision(6) << m_last_interval_wall_clock_time << " Cpu time(s) : "
+      fptr<<"GENOMICSDB_TIMER,";
+      if(!prefix.empty())
+        fptr << prefix <<",";
+      fptr << "Wall-clock time(s),"<< std::setprecision(6) << m_last_interval_wall_clock_time << ",Cpu time(s),"
         << m_last_interval_cpu_time << "\n";
     }
-    void print_cumulative(const std::string& prefix="", std::ostream& fptr = std::cout) const
+    void print(const std::string& prefix="", std::ostream& fptr = std::cout) const
     {
-      if(prefix.size() > 0u)
-        fptr << prefix <<" : ";
-      fptr << "Wall-clock time(s) : "<< std::setprecision(6) << m_cumulative_wall_clock_time << " Cpu time(s) : "
-        << m_cumulative_cpu_time << " Critical path wall-clock time(s) : " << m_critical_path_wall_clock_time
-        << " Cpu time(s): " << m_critical_path_cpu_time
-        << " #critical path "<< m_num_times_in_critical_path << "\n";
+      fptr<<"GENOMICSDB_TIMER,";
+      if(!prefix.empty())
+        fptr << prefix <<",";
+      fptr << "Wall-clock time(s),"<< std::setprecision(6) << m_cumulative_wall_clock_time << ",Cpu time(s),"
+        << m_cumulative_cpu_time << "\n";
+    }
+    void print_detail(const std::string& prefix="", std::ostream& fptr = std::cout) const
+    {
+      fptr<<"GENOMICSDB_TIMER,";
+      if(!prefix.empty())
+        fptr << prefix <<",";
+      fptr << "Wall-clock time(s),"<< std::setprecision(6) << m_cumulative_wall_clock_time << ",Cpu time(s),"
+        << m_cumulative_cpu_time << ",Critical path wall-clock time(s)," << m_critical_path_wall_clock_time
+        << ",Cpu time(s)," << m_critical_path_cpu_time
+        << ",#critical path,"<< m_num_times_in_critical_path << "\n";
     }
     void get_last_interval_times(std::vector<double>& timings, unsigned timer_idx) const
     {

--- a/include/utils/timer.h
+++ b/include/utils/timer.h
@@ -68,10 +68,10 @@ class Timer
       /*Wall clock time*/
       struct timeval end_time;
       gettimeofday(&end_time, 0);
-      m_last_interval_cpu_time = ((double)(static_cast<uint64_t>(end_cpu_time.tv_sec - m_begin_cpu_time.tv_sec)*1000000000ull
-            + static_cast<uint64_t>(end_cpu_time.tv_nsec - m_begin_cpu_time.tv_nsec)))/1000000000ull;
-      m_last_interval_wall_clock_time = ((double)((end_time.tv_sec - m_begin_wall_clock_time.tv_sec)*1000000ull
-            + (end_time.tv_usec - m_begin_wall_clock_time.tv_usec)))/1000000;
+      m_last_interval_cpu_time = (static_cast<int64_t>(end_cpu_time.tv_sec - m_begin_cpu_time.tv_sec)*1000000000ll
+            + static_cast<int64_t>(end_cpu_time.tv_nsec - m_begin_cpu_time.tv_nsec));
+      m_last_interval_wall_clock_time = (static_cast<int64_t>(end_time.tv_sec - m_begin_wall_clock_time.tv_sec)*1000000ll
+            + static_cast<int64_t>(end_time.tv_usec - m_begin_wall_clock_time.tv_usec));
       m_cumulative_cpu_time += m_last_interval_cpu_time;
       m_cumulative_wall_clock_time += m_last_interval_wall_clock_time;
     }
@@ -80,25 +80,26 @@ class Timer
       fptr<<"GENOMICSDB_TIMER,";
       if(!prefix.empty())
         fptr << prefix <<",";
-      fptr << "Wall-clock time(s),"<< std::setprecision(6) << m_last_interval_wall_clock_time << ",Cpu time(s),"
-        << m_last_interval_cpu_time << "\n";
+      fptr << "Wall-clock time(s),"<< std::setprecision(6) << ((double)m_last_interval_wall_clock_time)/1000000ll << ",Cpu time(s),"
+        << ((double)m_last_interval_cpu_time)/1000000000ll << "\n";
     }
     void print(const std::string& prefix="", std::ostream& fptr = std::cout) const
     {
       fptr<<"GENOMICSDB_TIMER,";
       if(!prefix.empty())
         fptr << prefix <<",";
-      fptr << "Wall-clock time(s),"<< std::setprecision(6) << m_cumulative_wall_clock_time << ",Cpu time(s),"
-        << m_cumulative_cpu_time << "\n";
+      fptr << "Wall-clock time(s),"<< std::setprecision(6) << ((double)m_cumulative_wall_clock_time)/1000000ll << ",Cpu time(s),"
+        << ((double)m_cumulative_cpu_time)/1000000000ll << "\n";
     }
     void print_detail(const std::string& prefix="", std::ostream& fptr = std::cout) const
     {
       fptr<<"GENOMICSDB_TIMER,";
       if(!prefix.empty())
         fptr << prefix <<",";
-      fptr << "Wall-clock time(s),"<< std::setprecision(6) << m_cumulative_wall_clock_time << ",Cpu time(s),"
-        << m_cumulative_cpu_time << ",Critical path wall-clock time(s)," << m_critical_path_wall_clock_time
-        << ",Cpu time(s)," << m_critical_path_cpu_time
+      fptr << "Wall-clock time(s),"<< std::setprecision(6) << ((double)m_cumulative_wall_clock_time)/1000000ll
+        << ",Cpu time(s)," << ((double)m_cumulative_cpu_time)/1000000000ll
+        << ",Critical path wall-clock time(s)," << ((double)m_critical_path_wall_clock_time)/1000000ll
+        << ",Cpu time(s)," << ((double)m_critical_path_cpu_time)/1000000000ll
         << ",#critical path,"<< m_num_times_in_critical_path << "\n";
     }
     void get_last_interval_times(std::vector<double>& timings, unsigned timer_idx) const
@@ -129,14 +130,14 @@ class Timer
     /*clock_t m_begin_cpu_time;*/
     struct timespec m_begin_cpu_time;
     struct timeval m_begin_wall_clock_time;
-    //seconds
-    double m_last_interval_cpu_time;
-    double m_last_interval_wall_clock_time;
-    double m_cumulative_cpu_time;
-    double m_cumulative_wall_clock_time;
+    //wall clock in micro-seconds, cpu time in nano-seconds
+    uint64_t m_last_interval_cpu_time;
+    uint64_t m_last_interval_wall_clock_time;
+    uint64_t m_cumulative_cpu_time;
+    uint64_t m_cumulative_wall_clock_time;
     //critical path contribution
-    double m_critical_path_wall_clock_time;
-    double m_critical_path_cpu_time;
+    uint64_t m_critical_path_wall_clock_time;
+    uint64_t m_critical_path_cpu_time;
     uint64_t m_num_times_in_critical_path;
 };
 

--- a/include/vcf/vcf_adapter.h
+++ b/include/vcf/vcf_adapter.h
@@ -29,6 +29,7 @@
 #include "gt_common.h"
 #include "htslib/vcf.h"
 #include "htslib/faidx.h"
+#include "timer.h"
 
 //Exceptions thrown
 class VCFAdapterException : public std::exception {
@@ -123,6 +124,10 @@ class VCFAdapter
     size_t m_combined_vcf_records_buffer_size_limit;
     //GATK CombineGVCF does not produce GT field by default - option to produce GT
     bool m_produce_GT_field;
+#ifdef DO_PROFILING
+    //Timer
+    Timer m_vcf_serialization_timer;
+#endif
 };
 
 class BufferedVCFAdapter : public VCFAdapter, public CircularBufferController

--- a/src/genomicsdb/variant_storage_manager.cc
+++ b/src/genomicsdb/variant_storage_manager.cc
@@ -46,6 +46,7 @@ VariantArrayCellIterator::VariantArrayCellIterator(TileDB_CTX* tiledb_ctx, const
   m_variant_array_schema(&variant_array_schema), m_cell(variant_array_schema, attribute_ids)
 #ifdef DO_PROFILING
   , m_tiledb_timer()
+  , m_tiledb_to_buffer_cell_timer()
 #endif
 {
   m_buffers.clear();
@@ -99,6 +100,9 @@ VariantArrayCellIterator::VariantArrayCellIterator(TileDB_CTX* tiledb_ctx, const
 
 const BufferVariantCell& VariantArrayCellIterator::operator*()
 {
+#ifdef DO_PROFILING
+  m_tiledb_to_buffer_cell_timer.start();
+#endif
   const uint8_t* field_ptr = 0;
   size_t field_size = 0u;
   for(auto i=0u;i<m_num_queried_attributes;++i)
@@ -116,6 +120,9 @@ const BufferVariantCell& VariantArrayCellIterator::operator*()
   assert(field_size == m_variant_array_schema->dim_size_in_bytes());
   auto coords_ptr = reinterpret_cast<const int64_t*>(field_ptr);
   m_cell.set_coordinates(coords_ptr[0], coords_ptr[1]);
+#ifdef DO_PROFILING
+  m_tiledb_to_buffer_cell_timer.stop();
+#endif
   return m_cell;
 }
 

--- a/src/loader/load_operators.cc
+++ b/src/loader/load_operators.cc
@@ -431,7 +431,7 @@ void LoaderCombinedGVCFOperator::finish(const int64_t column_interval_end)
   while(operator_overflow)
   {
     m_query_processor->handle_gvcf_ranges(m_end_pq, m_query_config, m_variant, *m_operator,
-        m_current_start_position, m_next_start_position, column_interval_end == INT64_MAX, m_num_calls_with_deletions);
+        m_current_start_position, m_next_start_position, column_interval_end == INT64_MAX, m_num_calls_with_deletions, m_stats_ptr);
     operator_overflow = m_operator->overflow(); //must be queried before post_operate_sequential and flush_output() are called
 #ifdef DO_MEMORY_PROFILING
     statm_t mem_result;

--- a/src/loader/tiledb_loader.cc
+++ b/src/loader/tiledb_loader.cc
@@ -579,12 +579,12 @@ void VCF2TileDBLoader::finish_read_all(const VCF2TileDBLoaderReadState& read_sta
   auto& flush_output_timer = read_state.m_flush_output_timer;
   for(auto op : m_operators)
     op->finish(get_column_partition_end());
-  fetch_timer.print_cumulative("Fetch from VCF", std::cerr);
-  load_timer.print_cumulative("Combining cells", std::cerr);
-  flush_output_timer.print_cumulative("Flush output", std::cerr);
-  read_state.m_sections_timer.print_cumulative("Sections time", std::cerr);
-  read_state.m_single_thread_phase_timer.print_cumulative("Time in single thread phase()", std::cerr);
-  read_state.m_time_in_read_all.print_cumulative("Time in read_all()", std::cerr);
+  fetch_timer.print_detail("Fetch from VCF", std::cerr);
+  load_timer.print_detail("Combining cells", std::cerr);
+  flush_output_timer.print_detail("Flush output", std::cerr);
+  read_state.m_sections_timer.print_detail("Sections time", std::cerr);
+  read_state.m_single_thread_phase_timer.print_detail("Time in single thread phase()", std::cerr);
+  read_state.m_time_in_read_all.print_detail("Time in read_all()", std::cerr);
 }
 
 void VCF2TileDBLoader::read_all(VCF2TileDBLoaderReadState& read_state)

--- a/src/main/java/com/intel/genomicsdb/GenomicsDBTimer.java
+++ b/src/main/java/com/intel/genomicsdb/GenomicsDBTimer.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License (MIT)
+ * Copyright (c) 2016 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of 
+ * this software and associated documentation files (the "Software"), to deal in 
+ * the Software without restriction, including without limitation the rights to 
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of 
+ * the Software, and to permit persons to whom the Software is furnished to do so, 
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all 
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS 
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.intel.genomicsdb;
+import java.io.PrintStream;
+import java.lang.management.ManagementFactory;
+
+class GenomicsDBTimer
+{
+    private long mBeginWallClockTime = 0;
+    private long mBeginCpuTime = 0;
+
+    //Interval time
+    private long mLastIntervalWallClockTime = 0;
+    private long mLastIntervalCpuTime = 0;
+
+    //Cumulative time
+    private double mCumulativeWallClockTime = 0;
+    private double mCumulativeCpuTime = 0;
+
+    public GenomicsDBTimer()
+    {
+        start();
+    }
+
+    public void start()
+    {
+        mBeginWallClockTime = System.nanoTime();
+        mBeginCpuTime = ManagementFactory.getThreadMXBean().getCurrentThreadCpuTime();
+    }
+
+    public void stop()
+    {
+        long endWallClockTime = System.nanoTime();
+        long endCpuTime = ManagementFactory.getThreadMXBean().getCurrentThreadCpuTime();
+        mLastIntervalWallClockTime = (endWallClockTime - mBeginWallClockTime);
+        mLastIntervalCpuTime = (endCpuTime - mBeginCpuTime);
+        mCumulativeWallClockTime += (((double)mLastIntervalWallClockTime)/1e9);
+        mCumulativeCpuTime += (((double)mLastIntervalCpuTime)/1e9);
+    }
+
+    public void print(final String prefix, PrintStream fptr)
+    {
+        fptr.print("GENOMICSDB_TIMER,");
+        if(!prefix.isEmpty())
+            fptr.print(prefix+',');
+        fptr.println("Wall-clock time(s)," + mCumulativeWallClockTime + ",Cpu time(s),"
+                + mCumulativeCpuTime);
+    }
+}

--- a/src/query_operations/broad_combined_gvcf.cc
+++ b/src/query_operations/broad_combined_gvcf.cc
@@ -388,6 +388,9 @@ void BroadCombinedGVCFOperator::handle_FORMAT_fields(const Variant& variant)
 
 void BroadCombinedGVCFOperator::operate(Variant& variant, const VariantQueryConfig& query_config)
 {
+#ifdef DO_PROFILING
+  m_bcf_t_creation_timer.start();
+#endif
   //Handle spanning deletions - change ALT alleles in calls with deletions to *, <NON_REF>
   handle_deletions(variant, query_config);
   GA4GHOperator::operate(variant, query_config);
@@ -459,6 +462,9 @@ void BroadCombinedGVCFOperator::operate(Variant& variant, const VariantQueryConf
   handle_INFO_fields(variant);
   //FORMAT fields
   handle_FORMAT_fields(variant);
+#ifdef DO_PROFILING
+  m_bcf_t_creation_timer.stop();
+#endif
   m_vcf_adapter->handoff_output_bcf_line(m_bcf_out, m_bcf_record_size);
 }
 

--- a/src/utils/json_config.cc
+++ b/src/utils/json_config.cc
@@ -197,7 +197,7 @@ void JSONConfigBase::read_from_file(const std::string& filename, const VidMapper
         VERIFY_OR_THROW(curr_partition_info_dict.HasMember("begin"));
         m_column_ranges[partition_idx].resize(1);      //only 1 std::pair
         m_column_ranges[partition_idx][0].first = curr_partition_info_dict["begin"].GetInt64();
-        m_column_ranges[partition_idx][0].second = INT64_MAX;
+        m_column_ranges[partition_idx][0].second = INT64_MAX-1;
         if(curr_partition_info_dict.HasMember("end"))
           m_column_ranges[partition_idx][0].second = curr_partition_info_dict["end"].GetInt64();
         if(m_column_ranges[partition_idx][0].first > m_column_ranges[partition_idx][0].second)

--- a/src/vcf/genomicsdb_bcf_generator.cc
+++ b/src/vcf/genomicsdb_bcf_generator.cc
@@ -82,7 +82,7 @@ GenomicsDBBCFGenerator::~GenomicsDBBCFGenerator()
     delete m_storage_manager;
   m_storage_manager = 0;
 #ifdef DO_PROFILING
-  m_timer.print_cumulative("GenomicsDBBCFGenerator ", std::cerr);
+  m_timer.print("GenomicsDBBCFGenerator", std::cerr);
 #endif
 }
 

--- a/src/vcf/vcf_adapter.cc
+++ b/src/vcf/vcf_adapter.cc
@@ -202,6 +202,9 @@ VCFAdapter::~VCFAdapter()
   if(m_open_output && m_output_fptr)
     bcf_close(m_output_fptr);
   m_output_fptr = 0;
+#ifdef DO_PROFILING
+  m_vcf_serialization_timer.print("bcf_t serialization", std::cerr);
+#endif
 }
 
 void VCFAdapter::clear()
@@ -368,6 +371,9 @@ void VCFSerializedBufferAdapter::print_header()
 
 void VCFSerializedBufferAdapter::handoff_output_bcf_line(bcf1_t*& line, const size_t bcf_record_size)
 {
+#ifdef DO_PROFILING
+  m_vcf_serialization_timer.start();
+#endif
   assert(m_rw_buffer);
   auto offset = bcf_serialize(line, &(m_rw_buffer->m_buffer[0]), m_rw_buffer->m_num_valid_bytes, m_rw_buffer->m_buffer.size(),
        m_is_bcf ? 1u : 0u, m_template_vcf_hdr, &m_hts_string);
@@ -379,6 +385,9 @@ void VCFSerializedBufferAdapter::handoff_output_bcf_line(bcf1_t*& line, const si
        m_is_bcf ? 1u : 0u, m_template_vcf_hdr, &m_hts_string);
   }
   m_rw_buffer->m_num_valid_bytes = offset;
+#ifdef DO_PROFILING
+  m_vcf_serialization_timer.stop();
+#endif
 }
 
 #endif //ifdef HTSDIR

--- a/tools/src/gt_mpi_gather.cc
+++ b/tools/src/gt_mpi_gather.cc
@@ -333,7 +333,7 @@ void scan_and_produce_Broad_GVCF(const VariantQueryProcessor& qp, const VariantQ
     }
   }
   timer.stop();
-  timer.print("Rank : "+std::to_string(my_world_mpi_rank)+" ", std::cerr);
+  timer.print(std::string("Total scan_and_produce_Broad_GVCF time")+" for rank "+std::to_string(my_world_mpi_rank), std::cerr);
 }
 #endif
 


### PR DESCRIPTION
* Provide timers for critical path in the loader
* Avoid recreating OpenMP thread groups in read_all() - no real
difference in performance