### PR TITLE
must add produceTileDBArray() option in import configuration; added r…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
                     <execution>
                         <id>attach-sources</id>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>jar-no-fork</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -244,6 +244,31 @@
                         <id>attach-javadocs</id>
                         <goals>
                             <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.5</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/main/java/com/intel/genomicsdb/GenomicsDBImporter.java
+++ b/src/main/java/com/intel/genomicsdb/GenomicsDBImporter.java
@@ -64,6 +64,7 @@ public class GenomicsDBImporter
   private static final String mTempLoaderJSONFileName = ".tmp_loader.json";
   private final String DEFAULT_ARRAYNAME = "genomicsdb_array";
   private final long DEFAULT_SIZE_PER_COLUMN_PARTITION = 10*1024L;
+  private final int DEFAULT_TILEDB_CELLS_PER_TILE = 1000;
 
 
   /*
@@ -333,6 +334,8 @@ public class GenomicsDBImporter
         .setRowBasedPartitioning(false)
         .setSizePerColumnPartition(sizePerColumnPartition)
         .addColumnPartitions(p0)
+        .setProduceTiledbArray(true)
+        .setNumCellsPerTile(DEFAULT_TILEDB_CELLS_PER_TILE)
         .setCompressTiledbArray(true)
         .setSegmentSize(segmentSize)
         .build();


### PR DESCRIPTION
1. set produce tiledb array in importconfiguration in GenomicsDBImporter
2. added maven plugins to automatically created gpg keys and push jars to oss.sonatype.org/nexus