### PR TITLE
Java batched import

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,9 +233,17 @@ if(BUILD_JAVA)
     #Maven build - depends on dynamic library
     add_custom_command(
         OUTPUT ${GENOMICSDB_MAVEN_BUILD_DIR}/genomicsdb-${GENOMICSDB_RELEASE_VERSION}.jar ${GENOMICSDB_MAVEN_BUILD_DIR}/genomicsdb-${GENOMICSDB_RELEASE_VERSION}-jar-with-dependencies.jar
-        COMMAND mvn package -DskipTests -Dgenomicsdb.version=${GENOMICSDB_RELEASE_VERSION} -Dgenomicsdb_lib_directory=$<TARGET_FILE_DIR:tiledbgenomicsdb> -Dgenomicsdb_build_directory=${GENOMICSDB_MAVEN_BUILD_DIR} ${MAVEN_PROTOBUF_REGENERATE_ARGS} -Dprotobuf.version=${GENOMICSDB_PROTOBUF_VERSION}
-        DEPENDS tiledbgenomicsdb ${JAVA_SCALA_SOURCES}
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/pom.xml ${CMAKE_BINARY_DIR}/pom.xml
+        COMMAND mvn versions:set -DnewVersion=${GENOMICSDB_RELEASE_VERSION}
+        COMMAND mvn package -DskipTests
+          -Dgenomicsdb.version=${GENOMICSDB_RELEASE_VERSION}
+          -Dgenomicsdb_source_directory=${CMAKE_SOURCE_DIR}
+          -Dgenomicsdb_build_directory=${GENOMICSDB_MAVEN_BUILD_DIR}
+          -Dgenomicsdb_lib_directory=$<TARGET_FILE_DIR:tiledbgenomicsdb>
+          -Dprotobuf.version=${GENOMICSDB_PROTOBUF_VERSION}
+          ${MAVEN_PROTOBUF_REGENERATE_ARGS}
+        DEPENDS tiledbgenomicsdb ${JAVA_SCALA_SOURCES} pom.xml
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
     add_custom_target(mvn_package ALL
         DEPENDS ${GENOMICSDB_MAVEN_BUILD_DIR}/genomicsdb-${GENOMICSDB_RELEASE_VERSION}.jar ${GENOMICSDB_MAVEN_BUILD_DIR}/genomicsdb-${GENOMICSDB_RELEASE_VERSION}-jar-with-dependencies.jar)
     install(FILES ${GENOMICSDB_MAVEN_BUILD_DIR}/genomicsdb-${GENOMICSDB_RELEASE_VERSION}.jar ${GENOMICSDB_MAVEN_BUILD_DIR}/genomicsdb-${GENOMICSDB_RELEASE_VERSION}-jar-with-dependencies.jar DESTINATION bin)
@@ -243,5 +251,11 @@ endif()
 
 enable_testing()
 add_test(NAME all_java_tests
-         COMMAND mvn  test -Dgenomicsdb.version=${GENOMICSDB_RELEASE_VERSION} -Dprotobuf.version=${GENOMICSDB_PROTOBUF_VERSION} -Dgenomicsdb_lib_directory=$<TARGET_FILE_DIR:tiledbgenomicsdb> -Dgenomicsdb_build_directory=${GENOMICSDB_MAVEN_BUILD_DIR} ${MAVEN_PROTOBUF_REGENERATE_ARGS}
-         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+         COMMAND mvn test
+           -Dgenomicsdb.version=${GENOMICSDB_RELEASE_VERSION}
+           -Dgenomicsdb_source_directory=${CMAKE_SOURCE_DIR}
+           -Dgenomicsdb_build_directory=${GENOMICSDB_MAVEN_BUILD_DIR}
+           -Dgenomicsdb_lib_directory=$<TARGET_FILE_DIR:tiledbgenomicsdb>
+           -Dprotobuf.version=${GENOMICSDB_PROTOBUF_VERSION}
+           ${MAVEN_PROTOBUF_REGENERATE_ARGS}
+         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}})

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
     <protobuf.version>3.0.2</protobuf.version>
     <testng.version>6.10</testng.version>
     <gnu.getopt.version>1.0.13</gnu.getopt.version>
+    <genomicsdb_source_directory>.</genomicsdb_source_directory>
     <genomicsdb_lib_directory>bin</genomicsdb_lib_directory>
     <genomicsdb_build_directory>${project.basedir}/target</genomicsdb_build_directory>
     <protobuf.input.directory>${project.basedir}/src/resources</protobuf.input.directory>
@@ -293,8 +294,9 @@
                 </goals>
                 <configuration>
                   <sources>
-                    <source>src/main/protobuf-generated/java</source>
-                    <source>src/main/scala</source>
+                    <source>${genomicsdb_source_directory}/src/main/java</source>
+                    <source>${genomicsdb_source_directory}/src/main/scala</source>
+                    <source>${genomicsdb_source_directory}/src/main/protobuf-generated/java</source>
                   </sources>
                 </configuration>
               </execution>
@@ -359,8 +361,9 @@
                 </goals>
                 <configuration>
                   <sources>
+                    <source>${genomicsdb_source_directory}/src/main/java</source>
+                    <source>${genomicsdb_source_directory}/src/main/scala</source>
                     <source>${protobuf.output.directory}</source>
-                    <source>src/main/scala</source>
                   </sources>
                 </configuration>
               </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <genomicsdb_source_directory>.</genomicsdb_source_directory>
     <genomicsdb_lib_directory>bin</genomicsdb_lib_directory>
     <genomicsdb_build_directory>${project.basedir}/target</genomicsdb_build_directory>
-    <protobuf.input.directory>${project.basedir}/src/resources</protobuf.input.directory>
+    <protobuf.input.directory>${genomicsdb_source_directory}/src/resources</protobuf.input.directory>
     <protobuf.output.directory>${genomicsdb_build_directory}/protobuf</protobuf.output.directory>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -227,12 +227,12 @@
           <show>private</show>
           <nohelp>true</nohelp>
           <sourceFileExcludes>
-            <exclude>GenomicsDBVidMapProto.java</exclude>
-            <exclude>GenomicsDBCallsetsMapProto.java</exclude>
-            <exclude>GenomicsDBImportConfiguration.java</exclude>
-            <exclude>GenomicsDBExportConfiguration.java</exclude>
+            <exclude>**/GenomicsDBVidMapProto.java</exclude>
+            <exclude>**/GenomicsDBCallsetsMapProto.java</exclude>
+            <exclude>**/GenomicsDBImportConfiguration.java</exclude>
+            <exclude>**/GenomicsDBExportConfiguration.java</exclude>
           </sourceFileExcludes>
-          <sourcepath>${basedir}/src/main/protobuf-generated/com/intel/genomicsdb</sourcepath>
+          <sourcepath>${genomicsdb_source_directory}/src/main/java:${genomicsdb_source_directory}/src/main/scala:${genomicsdb_source_directory}/src/main/protobuf-generated/java</sourcepath>
         </configuration>
         <executions>
           <execution>

--- a/src/main/cpp/include/genomicsdb/query_variants.h
+++ b/src/main/cpp/include/genomicsdb/query_variants.h
@@ -169,6 +169,7 @@ class VariantQueryProcessorScanState
     VariantCallEndPQ& get_end_pq() { return m_end_pq; }
     Variant& get_variant() { return m_variant; }
     uint64_t get_num_calls_with_deletions() const { return m_num_calls_with_deletions; }
+    void set_done(const bool val) { m_done = val; }
     /*void set_num_calls_with_deletions(const uint64_t val) { m_num_calls_with_deletions = val; }*/
   private:
     bool m_done;

--- a/src/main/cpp/include/genomicsdb/variant_storage_manager.h
+++ b/src/main/cpp/include/genomicsdb/variant_storage_manager.h
@@ -214,9 +214,11 @@ class VariantStorageManager
     /*
      * Wrapper functions around the C-API
      */
+    bool check_if_TileDB_array_exists(const std::string& array_name);
     int open_array(const std::string& array_name, const char* mode);
     void close_array(const int ad);
     int define_array(const VariantArraySchema* variant_array_schema, const size_t num_cells_per_tile=1000u);
+    void delete_array(const std::string& array_name);
     int define_metadata_schema(const VariantArraySchema* variant_array_schema);
     /*
      * Load array schema

--- a/src/main/cpp/include/vcf/genomicsdb_bcf_generator.h
+++ b/src/main/cpp/include/vcf/genomicsdb_bcf_generator.h
@@ -37,14 +37,17 @@ class GenomicsDBBCFGenerator
         const char* chr, const int start, const int end,
         int my_rank=0, size_t buffer_capacity=DEFAULT_COMBINED_VCF_RECORDS_BUFFER_SIZE, size_t tiledb_segment_size=1048576u,
         const char* output_format="bu",
+        const bool produce_header_only=false,
         const bool use_missing_values_only_not_vector_end=false,
         const bool keep_idx_fields_in_bcf_header=true);
     GenomicsDBBCFGenerator(const std::string& loader_config_file, const std::string& query_config_file, int my_rank=0,
         size_t buffer_capacity=DEFAULT_COMBINED_VCF_RECORDS_BUFFER_SIZE, size_t tiledb_segment_size=1048576u, const char* output_format="bu",
+        const bool produce_header_only=false,
         const bool use_missing_values_only_not_vector_end=false)
       : GenomicsDBBCFGenerator(loader_config_file, query_config_file,
           "", 0, 0,
           my_rank, buffer_capacity, tiledb_segment_size, output_format,
+          produce_header_only,
           use_missing_values_only_not_vector_end)
       {  }
     //Delete copy and move constructors
@@ -72,6 +75,7 @@ class GenomicsDBBCFGenerator
     void produce_next_batch();
   private:
     bool m_done;
+    bool m_produce_header_only;
     FileBasedVidMapper m_vid_mapper;
     VariantStorageManager* m_storage_manager;
     VariantQueryProcessor* m_query_processor;

--- a/src/main/cpp/src/loader/load_operators.cc
+++ b/src/main/cpp/src/loader/load_operators.cc
@@ -135,9 +135,11 @@ LoaderArrayWriter::LoaderArrayWriter(
   //Storage manager
   size_t segment_size = m_loader_json_config.get_segment_size();
   m_storage_manager = new VariantStorageManager(workspace, segment_size);
-  auto mode = m_loader_json_config.delete_and_create_tiledb_array() ? "w" : "a";
+  if(m_loader_json_config.delete_and_create_tiledb_array())
+    m_storage_manager->delete_array(array_name);
+  //Open array in write mode
+  m_array_descriptor = m_storage_manager->open_array(array_name, "w");
   //Check if array already exists
-  m_array_descriptor = m_storage_manager->open_array(array_name, mode);
   //Array does not exist - define it first
   if(m_array_descriptor < 0)
   {

--- a/src/main/cpp/src/loader/tiledb_loader.cc
+++ b/src/main/cpp/src/loader/tiledb_loader.cc
@@ -1039,8 +1039,15 @@ int VCF2TileDBLoader::create_tiledb_workspace(const char* workspace)
   {
     if(status >= 0)
     {
-      std::cerr << "Directory " << workspace << " exists - doing nothing\n";
-      returnval = 1;
+      auto workspace_file = std::string(workspace)+ "/__tiledb_workspace.tdb";
+      status = stat(workspace_file.c_str(), &st);
+      //__tiledb_workspace.tdb not found or is not a file
+      if(status != 0 || !S_ISREG(st.st_mode))
+      {
+        std::cerr << "Directory " << workspace
+          << " exists, but is not a TileDB workspace (doesn't contain regular file __tiledb_workspace.tdb)\n";
+        returnval = -1;
+      }
     }
     else  //Doesn't exist, create workspace
     {

--- a/src/main/cpp/src/utils/vid_mapper_pb.cc
+++ b/src/main/cpp/src/utils/vid_mapper_pb.cc
@@ -101,6 +101,8 @@ int ProtoBufBasedVidMapper::parse_callset_protobuf(
     m_max_callset_row_idx = std::max(m_max_callset_row_idx, row_idx);
 
     auto file_idx = get_or_append_global_file_idx(stream_name);
+    if(static_cast<size_t>(row_idx) >= m_row_idx_to_info.size())
+      m_row_idx_to_info.resize(static_cast<size_t>(row_idx)+1u);
     const auto& curr_row_info = m_row_idx_to_info[row_idx];
 
     // If row information for the same callset is found,

--- a/src/main/java/com/intel/genomicsdb/GenomicsDBFeatureReader.java
+++ b/src/main/java/com/intel/genomicsdb/GenomicsDBFeatureReader.java
@@ -194,7 +194,7 @@ public class GenomicsDBFeatureReader<T extends Feature, SOURCE> implements Featu
         mQueryJSONFile = queryJSONFile;
         //Read header
         GenomicsDBQueryStream gdbStream = new GenomicsDBQueryStream(loaderJSONFile, queryJSONFile,
-                mCodec instanceof BCF2Codec);
+                mCodec instanceof BCF2Codec, true);
         SOURCE source = codec.makeSourceFromStream(gdbStream);
         mFCHeader = codec.readHeader(source);
         //Store sequence names

--- a/src/main/java/com/intel/genomicsdb/GenomicsDBImporter.java
+++ b/src/main/java/com/intel/genomicsdb/GenomicsDBImporter.java
@@ -592,6 +592,27 @@ public class GenomicsDBImporter
    * @param  variants  Variant Readers objects of the input GVCF files
    * @param useSamplesInOrderProvided  If True, do not sort the samples,
    *                                   use the order they appear in
+   * @return  Mappings of callset (sample) names to TileDB rows
+   */
+  static GenomicsDBCallsetsMapProto.CallsetMappingPB generateSortedCallSetMap(
+      final Map<String, FeatureReader<VariantContext>> variants,
+      boolean useSamplesInOrderProvided)
+  {
+      return GenomicsDBImporter.generateSortedCallSetMap(variants,
+              useSamplesInOrderProvided,
+              0l);
+  }
+
+  /**
+   * Creates a sorted list of callsets and generates unique TileDB
+   * row indices for them. Sorted to maintain order between
+   * distributed share-nothing load processes.
+   *
+   * Assume one sample per input GVCF file
+   *
+   * @param  variants  Variant Readers objects of the input GVCF files
+   * @param useSamplesInOrderProvided  If True, do not sort the samples,
+   *                                   use the order they appear in
    * @param lbRowIdx Smallest row idx which should be imported by this object
    * @return  Mappings of callset (sample) names to TileDB rows
    */

--- a/src/main/java/com/intel/genomicsdb/GenomicsDBImporter.java
+++ b/src/main/java/com/intel/genomicsdb/GenomicsDBImporter.java
@@ -365,6 +365,7 @@ public class GenomicsDBImporter
    * is developed specifically for GATK4 GenomicsDBImport tool.
    *
    * @param sampleToVCMap  Variant Readers objects of the input GVCF files
+   * @param mergedHeader Set of VCFHeaderLine from the merged header across all input files
    * @param chromosomeInterval  Chromosome interval to traverse input VCFs
    * @param workspace TileDB workspace
    * @param arrayname TileDB array name
@@ -374,6 +375,7 @@ public class GenomicsDBImporter
    * @param ubRowIdx Largest row idx which should be imported by this object
    * @param useSamplesInOrderProvided if true, don't sort samples, instead use in the the order provided
    * @param failIfUpdating if true, fail if updating an existing array
+   * @throws IOException when load into TileDB array fails
    */
   public GenomicsDBImporter(Map<String, FeatureReader<VariantContext>> sampleToVCMap,
                      Set<VCFHeaderLine> mergedHeader,
@@ -399,6 +401,7 @@ public class GenomicsDBImporter
    * is developed specifically for GATK4 GenomicsDBImport tool.
    *
    * @param sampleToVCMap  Variant Readers objects of the input GVCF files
+   * @param mergedHeader Set of VCFHeaderLine from the merged header across all input files
    * @param chromosomeInterval  Chromosome interval to traverse input VCFs
    * @param workspace TileDB workspace
    * @param arrayname TileDB array name
@@ -409,6 +412,7 @@ public class GenomicsDBImporter
    * @param useSamplesInOrderProvided if true, don't sort samples, instead use in the the order provided
    * @param failIfUpdating if true, fail if updating an existing array
    * @param rank Rank of object - corresponds to the partition index in the loader
+   * @throws IOException when load into TileDB array fails
    */
   public GenomicsDBImporter(Map<String, FeatureReader<VariantContext>> sampleToVCMap,
                      Set<VCFHeaderLine> mergedHeader,
@@ -474,7 +478,7 @@ public class GenomicsDBImporter
    * is developed specifically for GATK4 GenomicsDBImport tool.
    *
    * @param sampleToVCMap  Variant Readers objects of the input GVCF files
-   * @param mergedHeader  Headers from all input GVCF files merged into one
+   * @param mergedHeader Set of VCFHeaderLine from the merged header across all input files
    * @param chromosomeInterval  Chromosome interval to traverse input VCFs
    * @param workspace  TileDB workspace
    * @param arrayname  TileDB array name
@@ -635,6 +639,7 @@ public class GenomicsDBImporter
    * distributed share-nothing load processes.
    *
    * @param sampleNames list of sample names
+   * @return  Mappings of callset (sample) names to TileDB rows
    */
   public static GenomicsDBCallsetsMapProto.CallsetMappingPB generateSortedCallSetMap(
       List<String> sampleNames)
@@ -652,6 +657,7 @@ public class GenomicsDBImporter
    * @param sampleNames list of sample names
    * @param useSamplesInOrderProvided  If True, do not sort the samples,
    *                                   use the order they appear in
+   * @return  Mappings of callset (sample) names to TileDB rows
    */
   public static GenomicsDBCallsetsMapProto.CallsetMappingPB generateSortedCallSetMap(
       List<String> sampleNames,

--- a/src/main/java/com/intel/genomicsdb/GenomicsDBImporter.java
+++ b/src/main/java/com/intel/genomicsdb/GenomicsDBImporter.java
@@ -71,7 +71,7 @@ public class GenomicsDBImporter
   /*
    * JNI functions
    */
-  
+
   /**
    * Creates GenomicsDBImporter object when importing VCF files (no streams)
    * @param loaderJSONFile Path to loader JSON file
@@ -102,7 +102,7 @@ public class GenomicsDBImporter
 
   /**
    * Copy the vid map protocol buffer to C++ through JNI
-   * 
+   *
    * @param genomicsDBImporterHandle Reference to a C++ GenomicsDBImporter object
    * @param vidMapAsByteArray INFO, FORMAT, FILTER header lines and contig positions
    * @return Reference to a C++ GenomicsDBImporter object as long
@@ -290,9 +290,8 @@ public class GenomicsDBImporter
                      Long segmentSize) throws IOException {
       this(sampleToVCMap, mergedHeader, chromosomeInterval,
               workspace, arrayname, sizePerColumnPartition, segmentSize,
-              false);
+              (long)0, Long.MAX_VALUE-1);
   }
-
 
   /**
    * Constructor to create required data structures from a list
@@ -306,6 +305,40 @@ public class GenomicsDBImporter
    * @param arrayname TileDB array name
    * @param sizePerColumnPartition sizePerColumnPartition in bytes
    * @param segmentSize segmentSize in bytes
+   * @param lbRowIdx Smallest row idx which should be imported by this object
+   * @param ubRowIdx Largest row idx which should be imported by this object
+   * @throws  IOException  FeatureReader.query can throw an IOException if invalid file is used
+   */
+  public GenomicsDBImporter(Map<String, FeatureReader<VariantContext>> sampleToVCMap,
+                     Set<VCFHeaderLine> mergedHeader,
+                     ChromosomeInterval chromosomeInterval,
+                     String workspace,
+                     String arrayname,
+                     Long sizePerColumnPartition,
+                     Long segmentSize,
+                     Long lbRowIdx,
+                     Long ubRowIdx) throws IOException {
+      this(sampleToVCMap, mergedHeader, chromosomeInterval,
+              workspace, arrayname, sizePerColumnPartition, segmentSize,
+              lbRowIdx,
+              ubRowIdx,
+              false);
+  }
+
+  /**
+   * Constructor to create required data structures from a list
+   * of GVCF files and a chromosome interval. This constructor
+   * is developed specifically for GATK4 GenomicsDBImport tool.
+   *
+   * @param sampleToVCMap  Variant Readers objects of the input GVCF files
+   * @param mergedHeader  Headers from all input GVCF files merged into one
+   * @param chromosomeInterval  Chromosome interval to traverse input VCFs
+   * @param workspace TileDB workspace
+   * @param arrayname TileDB array name
+   * @param sizePerColumnPartition sizePerColumnPartition in bytes
+   * @param segmentSize segmentSize in bytes
+   * @param lbRowIdx Smallest row idx which should be imported by this object
+   * @param ubRowIdx Largest row idx which should be imported by this object
    * @param useSamplesInOrderProvided if true, don't sort samples, instead
    *                                  use in the the order provided
    * @throws  IOException  FeatureReader.query can throw an IOException if invalid file is used
@@ -317,9 +350,12 @@ public class GenomicsDBImporter
                      String arrayname,
                      Long sizePerColumnPartition,
                      Long segmentSize,
+                     Long lbRowIdx,
+                     Long ubRowIdx,
                      boolean useSamplesInOrderProvided) throws IOException {
       this(sampleToVCMap, mergedHeader, chromosomeInterval,
               workspace, arrayname, sizePerColumnPartition, segmentSize,
+              lbRowIdx, ubRowIdx,
               useSamplesInOrderProvided, false);
   }
 
@@ -334,6 +370,8 @@ public class GenomicsDBImporter
    * @param arrayname TileDB array name
    * @param sizePerColumnPartition sizePerColumnPartition in bytes
    * @param segmentSize segmentSize in bytes
+   * @param lbRowIdx Smallest row idx which should be imported by this object
+   * @param ubRowIdx Largest row idx which should be imported by this object
    * @param useSamplesInOrderProvided if true, don't sort samples, instead use in the the order provided
    * @param failIfUpdating if true, fail if updating an existing array
    */
@@ -344,8 +382,46 @@ public class GenomicsDBImporter
                      String arrayname,
                      Long sizePerColumnPartition,
                      Long segmentSize,
+                     Long lbRowIdx,
+                     Long ubRowIdx,
                      boolean useSamplesInOrderProvided,
                      boolean failIfUpdating) throws IOException {
+      this(sampleToVCMap, mergedHeader, chromosomeInterval,
+              workspace, arrayname, sizePerColumnPartition, segmentSize,
+              lbRowIdx, ubRowIdx,
+              useSamplesInOrderProvided, failIfUpdating,
+              0);
+  }
+
+  /**
+   * Constructor to create required data structures from a list
+   * of GVCF files and a chromosome interval. This constructor
+   * is developed specifically for GATK4 GenomicsDBImport tool.
+   *
+   * @param sampleToVCMap  Variant Readers objects of the input GVCF files
+   * @param chromosomeInterval  Chromosome interval to traverse input VCFs
+   * @param workspace TileDB workspace
+   * @param arrayname TileDB array name
+   * @param sizePerColumnPartition sizePerColumnPartition in bytes
+   * @param segmentSize segmentSize in bytes
+   * @param lbRowIdx Smallest row idx which should be imported by this object
+   * @param ubRowIdx Largest row idx which should be imported by this object
+   * @param useSamplesInOrderProvided if true, don't sort samples, instead use in the the order provided
+   * @param failIfUpdating if true, fail if updating an existing array
+   * @param rank Rank of object - corresponds to the partition index in the loader
+   */
+  public GenomicsDBImporter(Map<String, FeatureReader<VariantContext>> sampleToVCMap,
+                     Set<VCFHeaderLine> mergedHeader,
+                     ChromosomeInterval chromosomeInterval,
+                     String workspace,
+                     String arrayname,
+                     Long sizePerColumnPartition,
+                     Long segmentSize,
+                     Long lbRowIdx,
+                     Long ubRowIdx,
+                     boolean useSamplesInOrderProvided,
+                     boolean failIfUpdating,
+                     int rank) throws IOException {
     // Mark this flag so that protocol buffer based vid
     // and callset map are propagated to C++ GenomicsDBImporter
     mUsingVidMappingProtoBuf = true;
@@ -360,15 +436,15 @@ public class GenomicsDBImporter
 
     mVidMap = generateVidMapFromMergedHeader(mergedHeader);
 
-    mCallsetMap = generateSortedCallSetMap(sampleToVCMap, useSamplesInOrderProvided);
+    mCallsetMap = generateSortedCallSetMap(sampleToVCMap, useSamplesInOrderProvided, lbRowIdx);
     File importJSONFile = printLoaderJSONFile(importConfiguration, "");
 
-    initialize(importJSONFile.getAbsolutePath(), 0, 0, 0);
+    initialize(importJSONFile.getAbsolutePath(), rank, lbRowIdx, ubRowIdx);
     mChromosomeInterval =chromosomeInterval;
 
     mGenomicsDBImporterObjectHandle =
       jniInitializeGenomicsDBImporterObject(mLoaderJSONFile, mRank, mLbRowIdx, mUbRowIdx);
-    
+
     jniCopyVidMap(mGenomicsDBImporterObjectHandle, mVidMap.toByteArray());
     jniCopyCallsetMap(mGenomicsDBImporterObjectHandle, mCallsetMap.toByteArray());
 
@@ -381,15 +457,13 @@ public class GenomicsDBImporter
             (int) mChromosomeInterval.mBegin,
             (int) mChromosomeInterval.mEnd);
       String streamName = sampleInfo.getStreamName();
-      LinkedHashMap<Integer, SampleInfo> sampleIndexToInfo =
-        new LinkedHashMap<Integer, SampleInfo>();
       addSortedVariantContextIterator(
         streamName,
         (VCFHeader) featureReader.getHeader(),
         iterator,
         importConfiguration.getSizePerColumnPartition(),
         VariantContextWriterBuilder.OutputType.BCF_STREAM,
-        sampleIndexToInfo);
+        null);
     }
   }
 
@@ -518,26 +592,79 @@ public class GenomicsDBImporter
    * @param  variants  Variant Readers objects of the input GVCF files
    * @param useSamplesInOrderProvided  If True, do not sort the samples,
    *                                   use the order they appear in
+   * @param lbRowIdx Smallest row idx which should be imported by this object
    * @return  Mappings of callset (sample) names to TileDB rows
    */
   static GenomicsDBCallsetsMapProto.CallsetMappingPB generateSortedCallSetMap(
-    Map<String, FeatureReader<VariantContext>> variants,
-    boolean useSamplesInOrderProvided) {
-
+      final Map<String, FeatureReader<VariantContext>> variants,
+      boolean useSamplesInOrderProvided,
+      final long lbRowIdx)
+  {
     List<String> sampleNames = new ArrayList<>(variants.size());
     for (Map.Entry<String, FeatureReader<VariantContext>> v : variants.entrySet()) {
       VCFHeader h = (VCFHeader) v.getValue().getHeader();
       sampleNames.add(h.getSampleNamesInOrder().get(0));
     }
+    return GenomicsDBImporter.generateSortedCallSetMap(sampleNames, useSamplesInOrderProvided, lbRowIdx);
+  }
 
+  /**
+   * Creates a sorted list of callsets and generates unique TileDB
+   * row indices for them. Sorted to maintain order between
+   * distributed share-nothing load processes.
+   *
+   * @param sampleNames list of sample names
+   */
+  public static GenomicsDBCallsetsMapProto.CallsetMappingPB generateSortedCallSetMap(
+      List<String> sampleNames)
+  {
+    return GenomicsDBImporter.generateSortedCallSetMap(
+        sampleNames,
+        false, 0l);
+  }
+
+  /**
+   * Creates a sorted list of callsets and generates unique TileDB
+   * row indices for them. Sorted to maintain order between
+   * distributed share-nothing load processes.
+   *
+   * @param sampleNames list of sample names
+   * @param useSamplesInOrderProvided  If True, do not sort the samples,
+   *                                   use the order they appear in
+   */
+  public static GenomicsDBCallsetsMapProto.CallsetMappingPB generateSortedCallSetMap(
+      List<String> sampleNames,
+      boolean useSamplesInOrderProvided)
+  {
+    return GenomicsDBImporter.generateSortedCallSetMap(
+        sampleNames,
+        useSamplesInOrderProvided, 0l);
+  }
+
+  /**
+   * Creates a sorted list of callsets and generates unique TileDB
+   * row indices for them. Sorted to maintain order between
+   * distributed share-nothing load processes.
+   *
+   * @param sampleNames list of sample names
+   * @param useSamplesInOrderProvided  If True, do not sort the samples,
+   *                                   use the order they appear in
+   * @param lbRowIdx Smallest row idx which should be imported by this object
+   * @return  Mappings of callset (sample) names to TileDB rows
+   */
+  public static GenomicsDBCallsetsMapProto.CallsetMappingPB generateSortedCallSetMap(
+      List<String> sampleNames,
+      boolean useSamplesInOrderProvided,
+      final long lbRowIdx)
+  {
     if(!useSamplesInOrderProvided)
         Collections.sort(sampleNames);
 
     GenomicsDBCallsetsMapProto.CallsetMappingPB.Builder callsetMapBuilder =
       GenomicsDBCallsetsMapProto.CallsetMappingPB.newBuilder();
 
-    int tileDBRowIndex = 0;
-    
+    long tileDBRowIndex = lbRowIdx;
+
     for (String sampleName : sampleNames) {
       GenomicsDBCallsetsMapProto.SampleIDToTileDBIDMap.Builder idMapBuilder =
         GenomicsDBCallsetsMapProto.SampleIDToTileDBIDMap.newBuilder();
@@ -555,7 +682,6 @@ public class GenomicsDBImporter
     }
     return callsetMapBuilder.build();
   }
-
 
   /**
    * Initialize variables
@@ -687,7 +813,7 @@ public class GenomicsDBImporter
       .addAllContigs(contigs)
       .build();
   }
-  
+
 
   private GenomicsDBVidMapProto.InfoField remove(
     List<GenomicsDBVidMapProto.InfoField> infoFields,
@@ -1114,7 +1240,7 @@ public class GenomicsDBImporter
    * the column partition specified by the loader JSON file and rank/partition index
    * @param loaderJSONFile path to loader JSON file
    * @param partitionIdx rank/partition index
-   * @return list of ChromosomeInterval objects for the specified partition 
+   * @return list of ChromosomeInterval objects for the specified partition
    * @throws ParseException when there is a bug in the JNI interface and a faulty JSON is returned
    */
   private static ArrayList<ChromosomeInterval> getChromosomeIntervalsForColumnPartition(
@@ -1150,12 +1276,12 @@ public class GenomicsDBImporter
     }
     return chromosomeIntervals;
   }
-  
+
   /**
    * Utility function that returns a MultiChromosomeIterator given an AbstractFeatureReader
    * that will iterate over the VariantContext objects provided by the reader belonging
    * to the column partition specified by the loader JSON file and rank/partition index
-   * 
+   *
    * @param <SOURCE> LineIterator for VCFs, PositionalBufferedStream for BCFs
    * @param reader AbstractFeatureReader over VariantContext objects -
    *               SOURCE can vary - BCF v/s VCF for example
@@ -1175,7 +1301,7 @@ public class GenomicsDBImporter
             GenomicsDBImporter.getChromosomeIntervalsForColumnPartition(
               loaderJSONFile, partitionIdx));
   }
-  
+
   /**
    * Utility function that returns a MultiChromosomeIterator given an AbstractFeatureReader
    * that will iterate over the VariantContext objects provided by the reader belonging

--- a/src/main/java/com/intel/genomicsdb/GenomicsDBQueryStream.java
+++ b/src/main/java/com/intel/genomicsdb/GenomicsDBQueryStream.java
@@ -58,7 +58,8 @@ public class GenomicsDBQueryStream extends InputStream
     private native long jniGenomicsDBInit(String loaderJSONFile, String queryJSONFile,
             String chr, int start, int end,
             int rank, long bufferCapacity, long segmentSize,
-            boolean readAsBCF, boolean useMissingValuesOnlyNotVectorEnd, boolean keepIDXFieldsInHeader);
+            boolean readAsBCF, boolean produceHeaderOnly,
+            boolean useMissingValuesOnlyNotVectorEnd, boolean keepIDXFieldsInHeader);
     
     private native long jniGenomicsDBClose(long handle);
 
@@ -95,9 +96,22 @@ public class GenomicsDBQueryStream extends InputStream
     public GenomicsDBQueryStream(final String loaderJSONFile, final String queryJSONFile,
             final boolean readAsBCF)
     {
+        this(loaderJSONFile, queryJSONFile, readAsBCF, false);
+    }
+
+    /**
+     * Constructor
+     * @param loaderJSONFile GenomicsDB loader JSON configuration file
+     * @param queryJSONFile GenomicsDB query JSON configuration file
+     * @param readAsBCF serialize-deserialize VCF records as BCF2 records
+     * @param produceHeaderOnly produce only the header
+     */
+    public GenomicsDBQueryStream(final String loaderJSONFile, final String queryJSONFile,
+            final boolean readAsBCF, final boolean produceHeaderOnly)
+    {
         this(loaderJSONFile, queryJSONFile, "", 0, 0,
                 0, 10485760,10485760,
-                readAsBCF);
+                readAsBCF, produceHeaderOnly);
     }
 
     /**
@@ -128,7 +142,7 @@ public class GenomicsDBQueryStream extends InputStream
             final boolean readAsBCF)
     {
         this(loaderJSONFile, queryJSONFile, chr, start, end, 0, 10485760,
-          10485760, readAsBCF);
+          10485760, readAsBCF, false);
     }
  
     /**
@@ -165,7 +179,7 @@ public class GenomicsDBQueryStream extends InputStream
             final int rank, final long bufferCapacity, final long segmentSize)
     {
         this(loaderJSONFile, queryJSONFile, chr, start, end, rank, bufferCapacity,
-          segmentSize, mDefaultReadAsBCF);
+          segmentSize, mDefaultReadAsBCF, false);
     }
 
     /**
@@ -184,10 +198,11 @@ public class GenomicsDBQueryStream extends InputStream
     public GenomicsDBQueryStream(final String loaderJSONFile, final String queryJSONFile,
             final String chr, final int start, final int end,
             final int rank, final long bufferCapacity, final long segmentSize,
-            final boolean readAsBCF)
+            final boolean readAsBCF, final boolean produceHeaderOnly)
     {
         this(loaderJSONFile, queryJSONFile, chr, start, end, rank, bufferCapacity,
-          segmentSize, readAsBCF, mDefaultUseMissingOnlyNotVectorEnd, mDefaultKeepIDXFieldsInHeader);
+          segmentSize, readAsBCF, produceHeaderOnly,
+          mDefaultUseMissingOnlyNotVectorEnd, mDefaultKeepIDXFieldsInHeader);
     }
 
     /**
@@ -208,13 +223,15 @@ public class GenomicsDBQueryStream extends InputStream
     public GenomicsDBQueryStream(final String loaderJSONFile, final String queryJSONFile,
             final String chr, final int start, final int end,
             final int rank, final long bufferCapacity, final long segmentSize,
-            final boolean readAsBCF, final boolean useMissingValuesOnlyNotVectorEnd, final boolean keepIDXFieldsInHeader)
+            final boolean readAsBCF, final boolean produceHeaderOnly,
+            final boolean useMissingValuesOnlyNotVectorEnd, final boolean keepIDXFieldsInHeader)
     {
         mLoaderJSONFile = loaderJSONFile;
         mQueryJSONFile = queryJSONFile;
         mGenomicsDBReadStateHandle = jniGenomicsDBInit(loaderJSONFile, queryJSONFile, chr,
           start, end, rank, bufferCapacity, segmentSize,
-          readAsBCF, useMissingValuesOnlyNotVectorEnd, keepIDXFieldsInHeader);
+          readAsBCF, produceHeaderOnly,
+          useMissingValuesOnlyNotVectorEnd, keepIDXFieldsInHeader);
     }
 
     @Override

--- a/src/main/java/com/intel/genomicsdb/GenomicsDBQueryStream.java
+++ b/src/main/java/com/intel/genomicsdb/GenomicsDBQueryStream.java
@@ -194,6 +194,7 @@ public class GenomicsDBQueryStream extends InputStream
      *                       to store combined BCF2 records
      * @param segmentSize buffer to be used for querying TileDB
      * @param readAsBCF serialize-deserialize VCF records as BCF2 records
+     * @param produceHeaderOnly produce VCF/BCF header only - no records (minor optimization)
      */
     public GenomicsDBQueryStream(final String loaderJSONFile, final String queryJSONFile,
             final String chr, final int start, final int end,
@@ -217,6 +218,7 @@ public class GenomicsDBQueryStream extends InputStream
      *                       to store combined BCF2 records
      * @param segmentSize buffer to be used for querying TileDB
      * @param readAsBCF serialize-deserialize VCF records as BCF2 records
+     * @param produceHeaderOnly produce VCF/BCF header only - no records (minor optimization)
      * @param useMissingValuesOnlyNotVectorEnd don't add BCF2.2 vector end values
      * @param keepIDXFieldsInHeader keep BCF IDX fields in header
      */

--- a/src/main/jni/include/genomicsdb_GenomicsDBQueryStream.h
+++ b/src/main/jni/include/genomicsdb_GenomicsDBQueryStream.h
@@ -15,7 +15,7 @@ extern "C" {
  * Signature: (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IIIJJ)J
  */
 JNIEXPORT jlong JNICALL Java_com_intel_genomicsdb_GenomicsDBQueryStream_jniGenomicsDBInit
-  (JNIEnv *, jobject, jstring, jstring, jstring, jint, jint, jint, jlong, jlong, jboolean, jboolean, jboolean);
+  (JNIEnv *, jobject, jstring, jstring, jstring, jint, jint, jint, jlong, jlong, jboolean, jboolean, jboolean, jboolean);
 
 /*
  * Class:     com_intel_genomicsdb_GenomicsDBQueryStream

--- a/src/main/jni/src/genomicsdb_GenomicsDBQueryStream.cc
+++ b/src/main/jni/src/genomicsdb_GenomicsDBQueryStream.cc
@@ -30,7 +30,8 @@ JNIEXPORT jlong JNICALL Java_com_intel_genomicsdb_GenomicsDBQueryStream_jniGenom
   (JNIEnv* env, jobject curr_obj, jstring loader_configuration_file, jstring query_configuration_file,
    jstring chr, jint start, jint end,
    jint rank, jlong buffer_capacity, jlong segment_size,
-   jboolean is_bcf, jboolean use_missing_values_only_not_vector_end, jboolean keep_idx_fields_in_bcf_header)
+   jboolean is_bcf, jboolean produce_header_only,
+   jboolean use_missing_values_only_not_vector_end, jboolean keep_idx_fields_in_bcf_header)
 {
   //Java string to char*
   auto loader_configuration_file_cstr = env->GetStringUTFChars(loader_configuration_file, NULL);
@@ -44,6 +45,7 @@ JNIEXPORT jlong JNICALL Java_com_intel_genomicsdb_GenomicsDBQueryStream_jniGenom
   auto bcf_reader_obj = new GenomicsDBBCFGenerator(loader_configuration_file_cstr, query_configuration_file_cstr,
       chr_cstr, start, end,
       rank, buffer_capacity, segment_size, output_format,
+      produce_header_only,
       is_bcf && use_missing_values_only_not_vector_end, is_bcf && keep_idx_fields_in_bcf_header);
   //Cleanup
   env->ReleaseStringUTFChars(loader_configuration_file, loader_configuration_file_cstr);

--- a/tests/run.py
+++ b/tests/run.py
@@ -373,7 +373,8 @@ def main():
                     +' '+test_params_dict['stream_name_to_filename_mapping'],
                     shell=True, stdout=subprocess.PIPE);
         elif(test_name.find('java_genomicsdb_importer_from_vcfs') != -1):
-            arg_list = ' -L '+test_params_dict['chromosome_interval'] + ' -w ' + ws_dir + ' -A '+test_name + ' --use_samples_in_order ';
+            arg_list = ' -L '+test_params_dict['chromosome_interval'] + ' -w ' + ws_dir + ' -A '+test_name \
+                    +' --use_samples_in_order ' + ' --batchsize=2 ';
             with open(test_params_dict['callset_mapping_file'], 'rb') as cs_fptr:
                 callset_mapping_dict = json.load(cs_fptr, object_pairs_hook=OrderedDict)
                 for callset_name, callset_info in callset_mapping_dict['callsets'].iteritems():


### PR DESCRIPTION
* Batched import in Java
* Minor opt for producing header only
* Check if workspace is directory and __tiledb_workspace.tdb file exists
* _delete_and_create_tiledb_array_ in the loader JSON works now

I had thought that it would be better to handle this in C++ - but given the issues with sample ordering and FeatureReaders, it was better to push this functionality to the top level program. Functionality in the TestGenomicsDBImporter driver code must be replicated in the GATK-4 tool.