### PR TITLE
Added lower and upper bound for batch imports to the constructor which also takes in output vidmap and callsetmap json file paths

### DIFF
--- a/src/main/java/com/intel/genomicsdb/GenomicsDBImporter.java
+++ b/src/main/java/com/intel/genomicsdb/GenomicsDBImporter.java
@@ -471,7 +471,6 @@ public class GenomicsDBImporter
     }
   }
 
-
   /**
    * Constructor to create required data structures from a list
    * of GVCF files and a chromosome interval. This constructor
@@ -530,6 +529,39 @@ public class GenomicsDBImporter
         e.printStackTrace();
       }
     }
+  }
+
+  /**
+   * Constructor to create required data structures from a list
+   * of GVCF files and a chromosome interval. This constructor
+   * is developed specifically for GATK4 GenomicsDBImport tool.
+   *
+   * @param sampleToVCMap  Variant Readers objects of the input GVCF files
+   * @param mergedHeader Set of VCFHeaderLine from the merged header across all input files
+   * @param chromosomeInterval  Chromosome interval to traverse input VCFs
+   * @param workspace  TileDB workspace
+   * @param arrayname  TileDB array name
+   * @param sizePerColumnPartition  Buffer size allocated for each column partition
+   * @param segmentSize  Total buffer size allocated for all partitions to write to TileDB
+   * @param outputVidMapJSONFilePath  Optional parameter to store vid map JSON file to the
+   *                                  given path
+   * @param outputCallsetMapJSONFilePath  Optional parameter to store callset
+   *                                      map JSON file to the given path
+   * @throws IOException  File IO exception
+   */
+  public GenomicsDBImporter(Map<String, FeatureReader<VariantContext>> sampleToVCMap,
+                            Set<VCFHeaderLine> mergedHeader,
+                            ChromosomeInterval chromosomeInterval,
+                            String workspace,
+                            String arrayname,
+                            Long sizePerColumnPartition,
+                            Long segmentSize,
+                            String outputVidMapJSONFilePath,
+                            String outputCallsetMapJSONFilePath) throws IOException {
+
+    this(sampleToVCMap, mergedHeader, chromosomeInterval, workspace, arrayname,
+            sizePerColumnPartition, segmentSize, 0L, (long)(sampleToVCMap.size()-1),
+            outputVidMapJSONFilePath, outputCallsetMapJSONFilePath);
   }
 
   private GenomicsDBImportConfiguration.ImportConfiguration createImportConfiguration(

--- a/src/main/java/com/intel/genomicsdb/GenomicsDBImporter.java
+++ b/src/main/java/com/intel/genomicsdb/GenomicsDBImporter.java
@@ -484,6 +484,8 @@ public class GenomicsDBImporter
    * @param arrayname  TileDB array name
    * @param sizePerColumnPartition  Buffer size allocated for each column partition
    * @param segmentSize  Total buffer size allocated for all partitions to write to TileDB
+   * @param lbRowIdx Smallest row idx which should be imported by this object
+   * @param ubRowIdx Largest row idx which should be imported by this object
    * @param outputVidMapJSONFilePath  Optional parameter to store vid map JSON file to the
    *                                  given path
    * @param outputCallsetMapJSONFilePath  Optional parameter to store callset
@@ -497,11 +499,13 @@ public class GenomicsDBImporter
                             String arrayname,
                             Long sizePerColumnPartition,
                             Long segmentSize,
+                            Long lbRowIdx,
+                            Long ubRowIdx,
                             String outputVidMapJSONFilePath,
                             String outputCallsetMapJSONFilePath) throws IOException {
 
     this(sampleToVCMap, mergedHeader, chromosomeInterval, workspace, arrayname,
-      sizePerColumnPartition, segmentSize);
+      sizePerColumnPartition, segmentSize, lbRowIdx, ubRowIdx);
 
     if (!outputVidMapJSONFilePath.isEmpty()) {
       String vidMapJSONString = printToString(mVidMap);


### PR DESCRIPTION
Minor change in genomicsdb importer constructor