### PR TITLE
Minor improvement for JSON loader

### DIFF
--- a/src/main/cpp/include/utils/json_config.h
+++ b/src/main/cpp/include/utils/json_config.h
@@ -111,6 +111,9 @@ class JSONBasicQueryConfig : public JSONConfigBase
     void subset_query_column_ranges_based_on_partition(const JSONLoaderConfig* loader_config, const int rank);
 };
 
+#define JSON_LOADER_PARTITION_INFO_BEGIN_FIELD_NAME "begin"
+#define JSON_LOADER_PARTITION_INFO_END_FIELD_NAME "end"
+
 class JSONLoaderConfig : public JSONConfigBase
 {
   public:

--- a/src/main/cpp/include/utils/json_config.h
+++ b/src/main/cpp/include/utils/json_config.h
@@ -64,7 +64,9 @@ class JSONConfigBase
       clear();
     }
     void clear();
-    void read_from_file(const std::string& filename, const VidMapper* id_mapper=0);
+    static void extract_contig_interval_from_object(const rapidjson::Value& curr_json_object,
+        const VidMapper* id_mapper, ColumnRange& result);
+    void read_from_file(const std::string& filename, const VidMapper* id_mapper=0, const int rank=0);
     const std::string& get_workspace(const int rank) const;
     const std::string& get_array_name(const int rank) const;
     ColumnRange get_column_partition(const int rank, const unsigned idx=0u) const;

--- a/src/main/cpp/src/loader/tiledb_loader.cc
+++ b/src/main/cpp/src/loader/tiledb_loader.cc
@@ -662,12 +662,14 @@ void VCF2TileDBLoader::finish_read_all(const VCF2TileDBLoaderReadState& read_sta
   auto& flush_output_timer = read_state.m_flush_output_timer;
   for(auto op : m_operators)
     op->finish(get_column_partition_end());
+#ifdef DO_PROFILING
   fetch_timer.print_detail("Fetch from VCF", std::cerr);
   load_timer.print_detail("Combining cells", std::cerr);
   flush_output_timer.print_detail("Flush output", std::cerr);
   read_state.m_sections_timer.print_detail("Sections time", std::cerr);
   read_state.m_single_thread_phase_timer.print_detail("Time in single thread phase()", std::cerr);
   read_state.m_time_in_read_all.print_detail("Time in read_all()", std::cerr);
+#endif
 }
 
 void VCF2TileDBLoader::read_all(VCF2TileDBLoaderReadState& read_state)

--- a/src/main/cpp/src/utils/json_config.cc
+++ b/src/main/cpp/src/utils/json_config.cc
@@ -218,8 +218,8 @@ void JSONConfigBase::read_from_file(const std::string& filename, const VidMapper
           //{ "begin" : <Val> }
           const auto& curr_partition_info_dict = column_partitions_array[partition_idx];
           VERIFY_OR_THROW(curr_partition_info_dict.IsObject());
-          VERIFY_OR_THROW(curr_partition_info_dict.HasMember("begin"));
-          auto& begin_json_value = curr_partition_info_dict["begin"];
+          VERIFY_OR_THROW(curr_partition_info_dict.HasMember(JSON_LOADER_PARTITION_INFO_BEGIN_FIELD_NAME));
+          auto& begin_json_value = curr_partition_info_dict[JSON_LOADER_PARTITION_INFO_BEGIN_FIELD_NAME];
           //Either a TileDB column idx or a dictionary of the form { "chr1" : [ 5, 6 ] }
           VERIFY_OR_THROW(begin_json_value.IsInt64() || begin_json_value.IsObject());
           if(begin_json_value.IsInt64())
@@ -227,9 +227,9 @@ void JSONConfigBase::read_from_file(const std::string& filename, const VidMapper
           else
             extract_contig_interval_from_object(begin_json_value, id_mapper, m_column_ranges[partition_idx][0]);
           m_column_ranges[partition_idx][0].second = INT64_MAX-1;
-          if(curr_partition_info_dict.HasMember("end"))
+          if(curr_partition_info_dict.HasMember(JSON_LOADER_PARTITION_INFO_END_FIELD_NAME))
           {
-            auto& end_json_value = curr_partition_info_dict["end"];
+            auto& end_json_value = curr_partition_info_dict[JSON_LOADER_PARTITION_INFO_END_FIELD_NAME];
             //Either a TileDB column idx or a dictionary of the form { "chr1" : [ 5, 6 ] }
             VERIFY_OR_THROW(end_json_value.IsInt64() || end_json_value.IsObject());
             if(end_json_value.IsInt64())
@@ -333,12 +333,12 @@ void JSONConfigBase::read_from_file(const std::string& filename, const VidMapper
         {
           const auto& curr_partition_info_dict = row_partitions_array[partition_idx];
           VERIFY_OR_THROW(curr_partition_info_dict.IsObject());
-          VERIFY_OR_THROW(curr_partition_info_dict.HasMember("begin"));
+          VERIFY_OR_THROW(curr_partition_info_dict.HasMember(JSON_LOADER_PARTITION_INFO_BEGIN_FIELD_NAME));
           m_row_ranges[partition_idx].resize(1);      //only 1 std::pair
-          m_row_ranges[partition_idx][0].first = curr_partition_info_dict["begin"].GetInt64();
+          m_row_ranges[partition_idx][0].first = curr_partition_info_dict[JSON_LOADER_PARTITION_INFO_BEGIN_FIELD_NAME].GetInt64();
           m_row_ranges[partition_idx][0].second = INT64_MAX-1;
-          if(curr_partition_info_dict.HasMember("end"))
-            m_row_ranges[partition_idx][0].second = curr_partition_info_dict["end"].GetInt64();
+          if(curr_partition_info_dict.HasMember(JSON_LOADER_PARTITION_INFO_END_FIELD_NAME))
+            m_row_ranges[partition_idx][0].second = curr_partition_info_dict[JSON_LOADER_PARTITION_INFO_END_FIELD_NAME].GetInt64();
           if(m_row_ranges[partition_idx][0].first > m_row_ranges[partition_idx][0].second)
             std::swap<int64_t>(m_row_ranges[partition_idx][0].first, m_row_ranges[partition_idx][0].second);
           if(curr_partition_info_dict.HasMember("workspace"))
@@ -794,7 +794,7 @@ void JSONVCFAdapterConfig::read_from_file(const std::string& filename,
       // {"begin": x}
       auto& curr_partition_info_dict = column_partitions_array[static_cast<rapidjson::SizeType>(rank)];
       VERIFY_OR_THROW(curr_partition_info_dict.IsObject());
-      VERIFY_OR_THROW(curr_partition_info_dict.HasMember("begin"));
+      VERIFY_OR_THROW(curr_partition_info_dict.HasMember(JSON_LOADER_PARTITION_INFO_BEGIN_FIELD_NAME));
       if(curr_partition_info_dict.HasMember("vcf_output_filename"))
       {
         VERIFY_OR_THROW(curr_partition_info_dict["vcf_output_filename"].IsString());


### PR DESCRIPTION
The JSON loader file can now use contig positions for begin and end fields
Example:
```
{
  "column_partitions" : [
    { "begin": { "chr1": 100 }, "end": { "chr1": 5000 } }
  ]
}
```