### PR TITLE
Fix CMake to build without libdbi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,12 @@ set(LIBCSV_DIR "" CACHE PATH "Path to libcsv header and library")
 set(DO_PROFILING False CACHE BOOL "Collect some stats during execution - doesn't add much overhead")
 set(DO_MEMORY_PROFILING False CACHE BOOL "Collect memory consumption in parts of the combine gVCF program - high overhead")
 set(GENOMICSDB_MAVEN_BUILD_DIR ${CMAKE_BINARY_DIR}/target CACHE PATH "Path to maven build directory")
-set(LIBDBI_DIR "/usr" CACHE PATH "Path to libdbi install directory")
+set(LIBDBI_DIR "" CACHE PATH "Path to libdbi install directory")
 set(MAVEN_QUIET False CACHE BOOL "Do not print mvn messages")
+
+#See https://cmake.org/Wiki/CMake_RPATH_handling#Common_questions
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH True)
+enable_testing()
 
 #Platform check modules
 include(CheckIncludeFileCXX)
@@ -194,12 +198,12 @@ function(build_GenomicsDB_executable_common target)
         target_link_libraries(${target} ${LIBCSV_LIBRARY})
     endif()
     if(LIBDBI_FOUND)
-        target_link_libraries(${target} ${LIBDBI_DEV_LIBRARY} ${LIBPGSQL_DRIVER_LIBRARY})
+        target_link_libraries(${target} ${LIBPGSQL_DRIVER_LIBRARY} ${LIBDBI_DEV_LIBRARY})
     endif()
-    target_link_libraries(${target} ${OPENSSL_LIBRARIES} ${ZLIB_LIBRARIES} ${PROTOBUF_LIBRARIES})
     if(LIBRT_LIBRARY)
         target_link_libraries(${target} ${LIBRT_LIBRARY})
     endif()
+    target_link_libraries(${target} ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES} ${ZLIB_LIBRARIES})
     install(TARGETS ${target} RUNTIME DESTINATION bin)
 endfunction()
 
@@ -213,7 +217,6 @@ include_directories(${PROTOBUF_GENERATED_CXX_HDRS_INCLUDE_DIRS})
 add_subdirectory(tools)
 add_subdirectory(example)
 
-enable_testing()
 if(BUILD_JAVA)
     set(JAVA_SCALA_SOURCES
         ./src/main/java/com/intel/genomicsdb/GenomicsDBConfiguration.java
@@ -293,5 +296,4 @@ if(BUILD_JAVA)
         ${CMAKE_BINARY_DIR}
         ${CMAKE_INSTALL_PREFIX})
 
-    add_test(NAME All_GTests COMMAND runAllGTests)
 endif()

--- a/cmake/Modules/Findlibdbi.cmake
+++ b/cmake/Modules/Findlibdbi.cmake
@@ -2,12 +2,29 @@
 # Once done this will define
 # LIBDBI_FOUND - libdbi found
 
-find_path(LIBDBI_INCLUDE_DIR NAMES dbi.h HINTS "${LIBDBI_DIR}/include/dbi")
+find_path(LIBDBI_INCLUDE_DIR NAMES dbi/dbi.h HINTS "${LIBDBI_DIR}/include")
 
-find_library(LIBPGSQL_DRIVER_LIBRARY NAMES dbdpgsql HINTS "${LIBDBI_DIR}/lib/${CMAKE_C_LIBRARY_ARCHITECTURE}/dbd")
+find_library(LIBPGSQL_DRIVER_LIBRARY NAMES dbdpgsql HINTS "${LIBDBI_DIR}/lib/dbd")
 
-find_library(LIBDBI_DEV_LIBRARY NAMES dbi HINTS "${LIBDBI_DIR}/lib/${CMAKE_C_LIBRARY_ARCHITECTURE}")
+find_library(LIBDBI_DEV_LIBRARY NAMES dbi HINTS "${LIBDBI_DIR}/lib")
 
 include(FindPackageHandleStandardArgs)
 
 find_package_handle_standard_args(libdbi "Could not find libdbi headers and/or libraries ${DEFAULT_MSG}" LIBDBI_INCLUDE_DIR LIBDBI_DEV_LIBRARY LIBPGSQL_DRIVER_LIBRARY)
+
+if(LIBDBI_FOUND)
+    include(CheckCSourceCompiles)
+    file(READ ${CMAKE_SOURCE_DIR}/cmake/Modules/libdbi_test_program.c LIBDBI_C_TEST_SOURCE)
+    set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+    set(CMAKE_REQUIRED_FLAGS "-I${LIBDBI_INCLUDE_DIR}")
+    set(SAFE_CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES}")
+    set(CMAKE_REQUIRED_LIBRARIES ${LIBPGSQL_DRIVER_LIBRARY} ${LIBDBI_DEV_LIBRARY})
+    check_c_source_compiles("${LIBDBI_C_TEST_SOURCE}" LIBDBI_TEST_PROGRAM_COMPILES)
+    if(NOT LIBDBI_TEST_PROGRAM_COMPILES)
+        message(STATUS "libdbi headers and libraries found; however, test program fails to compile. GenomicsDB requires libdbi >= 0.9.0.")
+        message(STATUS "Mapping DB support disabled")
+        unset(LIBDBI_FOUND)
+    endif()
+    set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+    set(CMAKE_REQUIRED_LIBRARIES "${SAFE_CMAKE_REQUIRED_LIBRARIES}")
+endif()

--- a/cmake/Modules/libdbi_test_program.c
+++ b/cmake/Modules/libdbi_test_program.c
@@ -1,0 +1,29 @@
+#include <stdio.h>
+#include <dbi/dbi.h>
+
+int main() {
+  dbi_conn conn;
+  dbi_result result;
+  dbi_inst instance;
+
+  dbi_initialize_r(NULL, &instance);
+  conn = dbi_conn_new_r("pgsql", instance);
+
+  dbi_conn_set_option(conn, "host", "localhost");
+
+  if (dbi_conn_connect(conn) < 0)
+    exit(0);
+  else
+  {
+    result = dbi_conn_query(conn, "SELECT * from table");
+    if (result) {
+      while (dbi_result_next_row(result)) {
+        unsigned idnumber = dbi_result_get_uint(result, "id");
+      }
+      dbi_result_free(result);
+    }
+    dbi_conn_close(conn);
+  }
+  dbi_shutdown_r(instance);
+  return 0;
+}

--- a/src/test/cpp/src/CMakeLists.txt
+++ b/src/test/cpp/src/CMakeLists.txt
@@ -1,11 +1,15 @@
 find_package(GTest)
 if(GTEST_FOUND)
-    enable_testing()
     set(CPP_TEST_SOURCES
         main_testall.cc
-        test_mapping_data_loader.cc)
-    message("IN TEST: ${CPP_TEST_SOURCES}") 
+        )
+    if(LIBDBI_FOUND)
+        set(CPP_TEST_SOURCES
+            ${CPP_TEST_SOURCES}
+            test_mapping_data_loader.cc)
+    endif()
     add_executable(runAllGTests ${CPP_TEST_SOURCES})
     target_link_libraries(runAllGTests ${GTEST_BOTH_LIBRARIES})
     build_GenomicsDB_executable_common(runAllGTests)
+    add_test(NAME All_GTests COMMAND runAllGTests)
 endif()


### PR DESCRIPTION
* Disable compilation of tests associated with libdbi
* Requires version >= 0.9.0 of libdbi. CentOS-7 by default provides an
older version which causes compilation errors. Try compiling a simple
test program in the config phase. If it fails, disable mapping DB
related code