### PR TITLE
Update GenomicsDBQueryStream.java

### DIFF
--- a/src/main/java/com/intel/genomicsdb/GenomicsDBQueryStream.java
+++ b/src/main/java/com/intel/genomicsdb/GenomicsDBQueryStream.java
@@ -44,7 +44,7 @@ public class GenomicsDBQueryStream extends InputStream
         }
         catch(UnsatisfiedLinkError ule)
         {
-            throw new GenomicsDBException("Could not load genomicsdb native library");
+            throw new GenomicsDBException("Could not load genomicsdb native library", ule);
         }
     }
     private static boolean mDefaultReadAsBCF = true;


### PR DESCRIPTION
In the case that the library is missing a symbol, it would be helpful to print the original error message.