### PR TITLE
changes for spark locality 

### DIFF
--- a/src/main/java/com/intel/genomicsdb/GenomicsDBInputFormat.java
+++ b/src/main/java/com/intel/genomicsdb/GenomicsDBInputFormat.java
@@ -67,7 +67,7 @@ public class GenomicsDBInputFormat<VCONTEXT extends Feature, SOURCE>
 
     ArrayList<InputSplit> inputSplits = new ArrayList<>(hosts.size());
     for (int i = 0; i < hosts.size(); ++i) {
-      GenomicsDBInputSplit split = new GenomicsDBInputSplit();
+      GenomicsDBInputSplit split = new GenomicsDBInputSplit(hosts.get(i));
       inputSplits.add(split);
     }
 

--- a/src/main/java/com/intel/genomicsdb/GenomicsDBInputSplit.java
+++ b/src/main/java/com/intel/genomicsdb/GenomicsDBInputSplit.java
@@ -47,6 +47,11 @@ public class GenomicsDBInputSplit extends InputSplit implements Writable {
   public GenomicsDBInputSplit() {
   }
 
+  public GenomicsDBInputSplit(String loc) {
+    hosts = new String[1];
+    hosts[0] = loc;
+  }
+
   public GenomicsDBInputSplit(long length) {
     this.length = length;
   }
@@ -56,7 +61,6 @@ public class GenomicsDBInputSplit extends InputSplit implements Writable {
   }
 
   public void readFields(DataInput dataInput) throws IOException {
-    hosts = null;
     length = dataInput.readLong();
   }
 
@@ -71,8 +75,6 @@ public class GenomicsDBInputSplit extends InputSplit implements Writable {
    *                   in GenomicsDBConfiguration or hadoopConfiguration in SparkContext
    */
   public String[] getLocations() throws IOException, InterruptedException {
-    hosts = new String[1];
-    hosts[0] = InetAddress.getLocalHost().getHostName();
     return hosts;
   }
 }


### PR DESCRIPTION
This change associates an inputsplit with the node name in the hostfile. Combining this with assigning a very high value for spark.locality.wait ensures that when spark is scheduling tasks it will respect data locality and query all the nodes in a setup where the genomicsdb array has been partitioned across multiple nodes.