### PR TITLE
propagate underlying exception in GenomicsDBImporter.java on failure to load

### DIFF
--- a/src/main/java/com/intel/genomicsdb/GenomicsDBImporter.java
+++ b/src/main/java/com/intel/genomicsdb/GenomicsDBImporter.java
@@ -69,7 +69,7 @@ public class GenomicsDBImporter
     }
     catch(UnsatisfiedLinkError ule)
     {
-      throw new GenomicsDBException("Could not load genomicsdb native library");
+      throw new GenomicsDBException("Could not load genomicsdb native library", ule);
     }
   }
 


### PR DESCRIPTION
updating GenomicsDBImporter.java to have an improved error message when the native library fails to load