### PR TITLE
Pass through query JSON (backward compatibility)

### DIFF
--- a/src/main/java/com/intel/genomicsdb/GenomicsDBInputFormat.java
+++ b/src/main/java/com/intel/genomicsdb/GenomicsDBInputFormat.java
@@ -103,12 +103,12 @@ public class GenomicsDBInputFormat<VCONTEXT extends Feature, SOURCE>
       queryJson = configuration.get(GenomicsDBConfiguration.QUERYJSON);
     }
 
-    GenomicsDBExportConfiguration.ExportConfiguration.Builder exportConfigurationBuilder = GenomicsDBExportConfiguration.ExportConfiguration.newBuilder();
-    JsonFormat.merge(queryJson, exportConfigurationBuilder);
-    GenomicsDBExportConfiguration.ExportConfiguration exportConfiguration = exportConfigurationBuilder
-            .setWorkspace("").setReferenceGenome("").build();
+    //GenomicsDBExportConfiguration.ExportConfiguration.Builder exportConfigurationBuilder = GenomicsDBExportConfiguration.ExportConfiguration.newBuilder();
+    //JsonFormat.merge(queryJson, exportConfigurationBuilder);
+    //GenomicsDBExportConfiguration.ExportConfiguration exportConfiguration = exportConfigurationBuilder
+            //.setWorkspace("").setReferenceGenome("").build();
 
-    featureReader = new GenomicsDBFeatureReader<>(exportConfiguration,
+    featureReader = new GenomicsDBFeatureReader<>(queryJson,
             (FeatureCodec<VCONTEXT, SOURCE>) new BCF2Codec(), Optional.of(loaderJson));
     recordReader = new GenomicsDBRecordReader<>(featureReader);
     return recordReader;

--- a/src/main/java/com/intel/genomicsdb/reader/GenomicsDBFeatureReader.java
+++ b/src/main/java/com/intel/genomicsdb/reader/GenomicsDBFeatureReader.java
@@ -47,7 +47,7 @@ import static java.util.stream.Collectors.toList;
  */
 public class GenomicsDBFeatureReader<T extends Feature, SOURCE> implements FeatureReader<T> {
     private String loaderJSONFile;
-    private String userProvidedQueryJSONFilename = null;
+    private String queryJsonFileName = null;
     private GenomicsDBExportConfiguration.ExportConfiguration exportConfiguration;
     private FeatureCodec<T, SOURCE> codec;
     private FeatureCodecHeader featureCodecHeader;
@@ -88,7 +88,7 @@ public class GenomicsDBFeatureReader<T extends Feature, SOURCE> implements Featu
     public GenomicsDBFeatureReader(final String queryJSONFilename,
                                    final FeatureCodec<T, SOURCE> codec,
                                    final Optional<String> loaderJSONFile) throws IOException {
-        this.userProvidedQueryJSONFilename = queryJSONFilename;
+        this.queryJsonFileName = queryJSONFilename;
         this.codec = codec;
         this.loaderJSONFile = loaderJSONFile.orElse("");
         generateHeadersForQueryGivenQueryJSONFile(queryJSONFilename);
@@ -122,8 +122,9 @@ public class GenomicsDBFeatureReader<T extends Feature, SOURCE> implements Featu
      * @return iterator over {@link htsjdk.variant.variantcontext.VariantContext} objects
      */
     public CloseableTribbleIterator<T> iterator() throws IOException {
-        List<String> chromosomeIntervalArraysPaths = (this.userProvidedQueryJSONFilename != null)
-            ? Arrays.asList(this.userProvidedQueryJSONFilename)
+        List<String> chromosomeIntervalArraysPaths =
+          (this.queryJsonFileName != null && !this.queryJsonFileName.isEmpty())
+            ? Arrays.asList(this.queryJsonFileName)
             : this.exportConfiguration.hasArray() ? createArrayFolderListFromArrayStream(
                     new ArrayList<String>() {{
                         add(exportConfiguration.getArray());
@@ -142,8 +143,9 @@ public class GenomicsDBFeatureReader<T extends Feature, SOURCE> implements Featu
      * @return iterator over {@link htsjdk.variant.variantcontext.VariantContext} objects
      */
     public CloseableTribbleIterator<T> query(final String chr, final int start, final int end) throws IOException {
-        List<String> chromosomeIntervalArraysPaths = (this.userProvidedQueryJSONFilename != null)
-            ? Arrays.asList(this.userProvidedQueryJSONFilename)
+        List<String> chromosomeIntervalArraysPaths =
+          (this.queryJsonFileName != null && !this.queryJsonFileName.isEmpty())
+            ? Arrays.asList(this.queryJsonFileName)
             : this.exportConfiguration.hasArray() ? createArrayFolderListFromArrayStream(
                 new ArrayList<String>() {{
                     add(exportConfiguration.getArray());

--- a/tests/run.py
+++ b/tests/run.py
@@ -176,6 +176,11 @@ def main():
                         "batched_vcf": "golden_outputs/t0_1_2_vcf_at_0",
                         "java_vcf"   : "golden_outputs/java_t0_1_2_vcf_at_0",
                         } },
+                    { "query_column_ranges": [ [ [0, 1000000] ] ],
+                      "pass_through_query_json": True,
+                      "golden_output": {
+                        "java_vcf"   : "golden_outputs/java_t0_1_2_vcf_at_0",
+                        } },
                     { "query_column_ranges" : [{
                         "range_list": [{
                              "low": 0,
@@ -825,9 +830,13 @@ def main():
                             fptr.close();
                         if(query_type == 'java_vcf'):
                             loader_argument = loader_json_filename;
+                            misc_args = ''
                             if("query_without_loader" in query_param_dict and query_param_dict["query_without_loader"]):
                                 loader_argument = '""'
-                            query_command = 'java -ea TestGenomicsDB --query -l '+loader_argument+' '+query_json_filename;
+                            if("pass_through_query_json" in query_param_dict and query_param_dict["pass_through_query_json"]):
+                                misc_args = "--pass_through_query_json"
+                            query_command = 'java -ea TestGenomicsDB --query -l '+loader_argument+' '+query_json_filename \
+                                + ' ' + misc_args;
                             pid = subprocess.Popen(query_command, shell=True, stdout=subprocess.PIPE);
                         else:
                             if(query_type == 'consolidate_and_vcf'):


### PR DESCRIPTION
Keeping a GenomicsDBFeatureReader constructor which accepts a single query JSON from the user and passes it through to the C++ library
(backward compatibility).

CI test for this constructor