### PR TITLE
First iteration on GenomicsDBImporter refactoring

### DIFF
--- a/src/main/java/com/intel/genomicsdb/GenomicsDBImporter.java
+++ b/src/main/java/com/intel/genomicsdb/GenomicsDBImporter.java
@@ -124,9 +124,9 @@ public class GenomicsDBImporter {
      * @param sampleToVCMap             Variant Readers objects of the input GVCF files
      * @param mergedHeader              Set of VCFHeaderLine from the merged header across all input files
      * @param chromosomeInterval        Chromosome interval to traverse input VCFs
+     * @param validateSampleToReaderMap Check validity of sampleToreaderMap entries
      * @param importConfiguration       Protobuf configuration object containing related input
      *                                  parameters, filenames, etc.
-     * @param validateSampleToReaderMap Check validity of sampleToreaderMap entries
      * @throws IOException Throws file IO exception.
      */
     public GenomicsDBImporter(Map<String, FeatureReader<VariantContext>> sampleToVCMap,
@@ -145,6 +145,7 @@ public class GenomicsDBImporter {
      * @param sampleToReaderMap               Feature Readers objects corresponding to input GVCF files
      * @param mergedHeader                    Set of VCFHeaderLine from the merged header across all input files
      * @param chromosomeInterval              Chromosome interval to traverse input VCFs
+     * @param importConfiguration             Protobuf configuration object containing related input parameters, filenames, etc.
      * @param rank                            Rank of object - corresponds to the partition index in the loader
      * @param validateSampleToReaderMap       Check validity of sampleToreaderMap entries
      * @param passAsVcf                       Use the VCF format to pass data from Java to C++
@@ -156,7 +157,7 @@ public class GenomicsDBImporter {
                               final GenomicsDBImportConfiguration.ImportConfiguration importConfiguration,
                               final int rank,
                               final boolean validateSampleToReaderMap,
-                              final boolean passAsVcf) throws IOException, IllegalArgumentException {
+                              final boolean passAsVcf) throws IOException {
         // Mark this flag so that protocol buffer based vid
         // and callset map are propagated to C++ GenomicsDBImporter
         mUsingVidMappingProtoBuf = true;

--- a/src/main/java/com/intel/genomicsdb/SilentByteBufferStream.java
+++ b/src/main/java/com/intel/genomicsdb/SilentByteBufferStream.java
@@ -25,6 +25,8 @@ package com.intel.genomicsdb;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import static com.intel.genomicsdb.importer.Constants.DEFAULT_BUFFER_CAPACITY;
+
 /**
  * Buffer stream implementation - it's silent in the sense that when the buffer is full,
  * it doesn't raise an exception but just marks a a flag as full. It's up to the caller
@@ -43,7 +45,7 @@ class SilentByteBufferStream extends OutputStream
    */
   public SilentByteBufferStream()
   {
-    mBuffer = new byte[(int)GenomicsDBImporter.mDefaultBufferCapacity];
+    mBuffer = new byte[(int)DEFAULT_BUFFER_CAPACITY];
   }
 
   /**

--- a/src/main/java/com/intel/genomicsdb/importer/Constants.java
+++ b/src/main/java/com/intel/genomicsdb/importer/Constants.java
@@ -1,0 +1,27 @@
+package com.intel.genomicsdb.importer;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
+public final class Constants {
+
+    private Constants() {
+    }
+
+    public static final int DEFAULT_ZERO_BATCH_SIZE = 0;
+    //Allele specific annotation fields
+    public static final HashSet<String> R_LENGTH_HISTOGRAM_FIELDS_FLOAT_BINS = new HashSet<>(Arrays.asList(
+            "AS_RAW_BaseQRankSum",
+            "AS_RAW_MQRankSum",
+            "AS_RAW_ReadPosRankSum"
+    ));
+    public static final HashSet<String> R_LENGTH_TWO_DIM_FLOAT_VECTOR_FIELDS = new HashSet<>(Collections.singletonList(
+            "AS_RAW_MQ"
+    ));
+    public static final HashSet<String> R_LENGTH_TWO_DIM_INT_VECTOR_FIELDS = new HashSet<>(Collections.singletonList(
+            "AS_SB_TABLE"
+    ));
+    public static final String CHROMOSOME_INTERVAL_FOLDER = "%s#%d#%d";
+    public static final long DEFAULT_BUFFER_CAPACITY = 20480; //20KB
+}

--- a/src/resources/genomicsdb_import_config.proto
+++ b/src/resources/genomicsdb_import_config.proto
@@ -39,7 +39,7 @@ option java_outer_classname = "GenomicsDBImportConfiguration";
 message Partition {
   required int64 begin = 1;
   optional string workspace = 2;
-  optional string array = 3;
+  optional string array = 3 [default = "genomicsdb_array"];
   optional string vcf_output_filename = 4;
   optional int64 end = 5 [default = 0x7FFFFFFFFFFFFFFF ];
 }

--- a/src/test/java/com/intel/genomicsdb/GenomicsDBImporterSpec.java
+++ b/src/test/java/com/intel/genomicsdb/GenomicsDBImporterSpec.java
@@ -25,6 +25,7 @@ package com.intel.genomicsdb;
 import com.intel.genomicsdb.model.CommandLineImportConfig;
 import com.intel.genomicsdb.model.GenomicsDBCallsetsMapProto;
 import com.intel.genomicsdb.model.GenomicsDBExportConfiguration;
+import com.intel.genomicsdb.model.GenomicsDBImportConfiguration;
 import com.intel.genomicsdb.reader.GenomicsDBFeatureReader;
 import htsjdk.tribble.CloseableTribbleIterator;
 import htsjdk.tribble.FeatureReader;
@@ -68,14 +69,19 @@ public final class GenomicsDBImporterSpec {
         GenomicsDBCallsetsMapProto.CallsetMappingPB callsetMappingPB =
                 GenomicsDBImporter.generateSortedCallSetMap(sampleToReaderMap, true, false);
 
+        GenomicsDBImportConfiguration.Partition partition = GenomicsDBImportConfiguration.Partition.newBuilder()
+                .setBegin(0).setWorkspace(WORKSPACE.getAbsolutePath()).setArray(TEST_CHROMOSOME_NAME).build();
+
+        GenomicsDBImportConfiguration.ImportConfiguration importConfiguration =
+                GenomicsDBImportConfiguration.ImportConfiguration.newBuilder().addColumnPartitions(partition)
+                        .setSizePerColumnPartition(1024L).setSegmentSize(10000000L).build();
+
         GenomicsDBImporter importer = new GenomicsDBImporter(
                 sampleToReaderMap,
                 mergedHeader,
                 chromosomeInterval,
-                WORKSPACE.getAbsolutePath(),
-                TEST_CHROMOSOME_NAME,
-                1024L,
-                10000000L);
+                true,
+                importConfiguration);
 
         importer.importBatch();
 
@@ -100,14 +106,19 @@ public final class GenomicsDBImporterSpec {
         GenomicsDBCallsetsMapProto.CallsetMappingPB callsetMappingPB_A =
                 GenomicsDBImporter.generateSortedCallSetMap(sampleToReaderMap, true, false);
 
+        GenomicsDBImportConfiguration.Partition partition = GenomicsDBImportConfiguration.Partition.newBuilder()
+                .setBegin(0).setWorkspace(WORKSPACE.getAbsolutePath()).setArray(TEST_CHROMOSOME_NAME).build();
+
+        GenomicsDBImportConfiguration.ImportConfiguration importConfiguration =
+                GenomicsDBImportConfiguration.ImportConfiguration.newBuilder().addColumnPartitions(partition)
+                        .setSizePerColumnPartition(1024L).setSegmentSize(10000000L).build();
+
         GenomicsDBImporter importer = new GenomicsDBImporter(
                 sampleToReaderMap,
                 mergedHeaderLines,
                 chromosomeInterval,
-                WORKSPACE.getAbsolutePath(),
-                TEST_CHROMOSOME_NAME,
-                1024L,
-                10000000L);
+                true,
+                importConfiguration);
 
         GenomicsDBImporter.writeVidMapJSONFile(tempVidJsonFile.getAbsolutePath(), mergedHeaderLines);
         GenomicsDBImporter.writeVcfHeaderFile(tempVcfHeaderFile.getAbsolutePath(), mergedHeaderLines);


### PR DESCRIPTION
This is the first iteration of changes on GenomicsDBImport. I'm doing it in small chunks of changes so the reviewers can follow the line of them.

Main focus on:
- Removing ctors.
- Extracting constants to class.

Next:
- Get rid of BaseImportConfig or remove duplication with ImportConfiguration.
- Remove duplication.
- Move functionality to importer package.
- Extract JNI to a class and extend from it.
- Extract specializations such as generators.

Once C++ API w/ Protobuf support is in place:
- Remove the need of using intermediate JSONs.