### PR TITLE
GenomicsDBImporter API simplification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ src/main/java/com/intel/genomicsdb/model/GenomicsDBCallsetsMapProto.java
 src/main/java/com/intel/genomicsdb/model/GenomicsDBExportConfiguration.java
 src/main/java/com/intel/genomicsdb/model/GenomicsDBImportConfiguration.java
 src/main/java/com/intel/genomicsdb/model/GenomicsDBVidMapProto.java
+src/main/java/com/intel/genomicsdb/model/Coordinates.java
 src/main/java/com/intel/genomicsdb/GenomicsDBCallsetsMapProto.java
 src/main/java/com/intel/genomicsdb/GenomicsDBExportConfiguration.java
 src/main/java/com/intel/genomicsdb/GenomicsDBImportConfiguration.java

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,7 +274,7 @@ if(BUILD_JAVA)
         ./src/main/java/com/intel/genomicsdb/importer/MultiChromosomeIterator.java
         ./src/main/java/com/intel/genomicsdb/importer/SilentByteBufferStream.java
         ./src/main/java/com/intel/genomicsdb/model/CommandLineImportConfig.java
-        ./src/main/java/com/intel/genomicsdb/model/ParallelImportConfig.java
+        ./src/main/java/com/intel/genomicsdb/model/ImportConfig.java
         ./src/main/java/com/intel/genomicsdb/reader/GenomicsDBFeatureIterator.java
         ./src/main/java/com/intel/genomicsdb/reader/GenomicsDBFeatureReader.java
         ./src/main/java/com/intel/genomicsdb/reader/GenomicsDBQueryStream.java
@@ -296,7 +296,7 @@ if(BUILD_JAVA)
         ./src/test/java/com/intel/genomicsdb/model/GenomicsDBExportConfigurationSpec.java
         ./src/test/java/com/intel/genomicsdb/model/GenomicsDBImportConfigurationSpec.java
         ./src/test/java/com/intel/genomicsdb/model/GenomicsDBVidMappingProtoSpec.java
-        ./src/test/java/com/intel/genomicsdb/model/ParallelImportConfigSpec.java
+        ./src/test/java/com/intel/genomicsdb/model/ImportConfigSpec.java
         ./src/test/java/com/intel/genomicsdb/GenomicsDBTestUtils.java
         )
     if(PROTOBUF_REGENERATE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,6 +285,7 @@ if(BUILD_JAVA)
         ./src/main/java/com/intel/genomicsdb/spark/GenomicsDBJavaSparkFactory.java
         ./src/main/java/com/intel/genomicsdb/spark/GenomicsDBPartitionInfo.java
         ./src/main/java/com/intel/genomicsdb/spark/GenomicsDBRecordReader.java
+        ./src/main/java/com/intel/genomicsdb/Constants.java
         ./src/main/java/com/intel/genomicsdb/GenomicsDBLibLoader.java
         ./src/main/scala/com/intel/genomicsdb/GenomicsDBContext.scala
         ./src/main/scala/com/intel/genomicsdb/GenomicsDBPartition.scala

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,6 +291,7 @@ if(BUILD_JAVA)
         ./src/main/scala/com/intel/genomicsdb/GenomicsDBRDD.scala
         ./src/main/scala/com/intel/genomicsdb/GenomicsDBScalaSparkFactory.scala
         ./src/test/java/com/intel/genomicsdb/importer/GenomicsDBImporterSpec.java
+        ./src/test/java/com/intel/genomicsdb/reader/ChrArrayFolderComparatorSpec.java
         ./src/test/java/com/intel/genomicsdb/model/CommandLineImportConfigSpec.java
         ./src/test/java/com/intel/genomicsdb/model/GenomicsDBCallsetsMapProtoSpec.java
         ./src/test/java/com/intel/genomicsdb/model/GenomicsDBExportConfigurationSpec.java

--- a/example/java/TestBufferStreamGenomicsDBImporter.java
+++ b/example/java/TestBufferStreamGenomicsDBImporter.java
@@ -190,7 +190,7 @@ public final class TestBufferStreamGenomicsDBImporter
     if(args[0].equals("-iterators"))
     {
       //Much simpler interface if using Iterator<VariantContext>
-      loader.executeSingleImport();
+      loader.doSingleImport();
       assert loader.isDone();
     }
     else
@@ -222,7 +222,7 @@ public final class TestBufferStreamGenomicsDBImporter
                 currInfo.mNextVC = null;
           }
         }
-        loader.executeSingleImport();
+        loader.doSingleImport();
         numExhaustedBufferStreams = (int)loader.getNumExhaustedBufferStreams();
         for(int i=0;i<numExhaustedBufferStreams;++i)
           exhaustedBufferStreamIdxs[i] = loader.getExhaustedBufferStreamIndex(i);

--- a/example/java/TestGenomicsDB.java
+++ b/example/java/TestGenomicsDB.java
@@ -98,7 +98,7 @@ public final class TestGenomicsDB
               .setVcfHeaderFilename(templateVCFHeader)
               .setScanFull(true);
       if(!array.isEmpty())
-        exportConfigurationBuilder.setArray(array);
+        exportConfigurationBuilder.setArrayName(array);
       exportConfiguration = exportConfigurationBuilder.build();
       reader = new GenomicsDBFeatureReader<>(exportConfiguration, codec, Optional.of(loaderJSONFile));
     }

--- a/example/java/TestGenomicsDB.java
+++ b/example/java/TestGenomicsDB.java
@@ -90,13 +90,16 @@ public final class TestGenomicsDB
       //<template_VCF_header>
       assert(!loaderJSONFile.isEmpty());
       assert(!workspace.isEmpty());
-      assert(!array.isEmpty());
       assert(!referenceGenome.isEmpty());
-      exportConfiguration = GenomicsDBExportConfiguration.ExportConfiguration.newBuilder()
+      GenomicsDBExportConfiguration.ExportConfiguration.Builder exportConfigurationBuilder
+        = GenomicsDBExportConfiguration.ExportConfiguration.newBuilder()
               .setWorkspace(workspace)
-              .setArray(array)
               .setReferenceGenome(referenceGenome)
-              .setVcfHeaderFilename(templateVCFHeader).build();
+              .setVcfHeaderFilename(templateVCFHeader)
+              .setScanFull(true);
+      if(!array.isEmpty())
+        exportConfigurationBuilder.setArray(array);
+      exportConfiguration = exportConfigurationBuilder.build();
       reader = new GenomicsDBFeatureReader<>(exportConfiguration, codec, Optional.of(loaderJSONFile));
     }
     final VariantContextWriter writer =

--- a/example/java/TestGenomicsDBImporterWithMergedVCFHeader.java
+++ b/example/java/TestGenomicsDBImporterWithMergedVCFHeader.java
@@ -32,6 +32,7 @@ public final class TestGenomicsDBImporterWithMergedVCFHeader {
   public static void main(final String[] args) throws IOException, GenomicsDBException, ParseException, InterruptedException {
     CommandLineImportConfig config = new CommandLineImportConfig("TestGenomicsDBImporterWithMergedVCFHeader", args);
     GenomicsDBImporter importer = new GenomicsDBImporter(config);
-    importer.executeImport(2);
+    importer.executeImport();
   }
+
 }

--- a/example/java/TestGenomicsDBImporterWithMergedVCFHeader.java
+++ b/example/java/TestGenomicsDBImporterWithMergedVCFHeader.java
@@ -32,6 +32,6 @@ public final class TestGenomicsDBImporterWithMergedVCFHeader {
   public static void main(final String[] args) throws IOException, GenomicsDBException, ParseException, InterruptedException {
     CommandLineImportConfig config = new CommandLineImportConfig("TestGenomicsDBImporterWithMergedVCFHeader", args);
     GenomicsDBImporter importer = new GenomicsDBImporter(config);
-    importer.executeParallelImport();
+    importer.executeImport(1);
   }
 }

--- a/example/java/TestGenomicsDBImporterWithMergedVCFHeader.java
+++ b/example/java/TestGenomicsDBImporterWithMergedVCFHeader.java
@@ -32,6 +32,6 @@ public final class TestGenomicsDBImporterWithMergedVCFHeader {
   public static void main(final String[] args) throws IOException, GenomicsDBException, ParseException, InterruptedException {
     CommandLineImportConfig config = new CommandLineImportConfig("TestGenomicsDBImporterWithMergedVCFHeader", args);
     GenomicsDBImporter importer = new GenomicsDBImporter(config);
-    importer.executeImport(1);
+    importer.executeImport(2);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,7 @@
           <show>private</show>
           <nohelp>true</nohelp>
           <sourceFileExcludes>
+            <exclude>**/coordinates.java</exclude>
             <exclude>**/GenomicsDBVidMapProto.java</exclude>
             <exclude>**/GenomicsDBCallsetsMapProto.java</exclude>
             <exclude>**/GenomicsDBImportConfiguration.java</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
           <show>private</show>
           <nohelp>true</nohelp>
           <sourceFileExcludes>
-            <exclude>**/coordinates.java</exclude>
+            <exclude>**/Coordinates.java</exclude>
             <exclude>**/GenomicsDBVidMapProto.java</exclude>
             <exclude>**/GenomicsDBCallsetsMapProto.java</exclude>
             <exclude>**/GenomicsDBImportConfiguration.java</exclude>

--- a/src/main/cpp/include/utils/json_config.h
+++ b/src/main/cpp/include/utils/json_config.h
@@ -69,6 +69,7 @@ class JSONConfigBase
     static void extract_contig_interval_from_object(const rapidjson::Value& curr_json_object,
         const VidMapper* id_mapper, ColumnRange& result);
     static bool extract_interval_from_PB_struct_or_return_false(const rapidjson::Value& curr_json_object,
+        const VidMapper* id_mapper,
         ColumnRange& result);
     void read_from_file(const std::string& filename, const VidMapper* id_mapper=0, const int rank=0);
     const std::string& get_workspace(const int rank) const;
@@ -76,7 +77,7 @@ class JSONConfigBase
     ColumnRange get_column_partition(const int rank, const unsigned idx=0u) const;
     RowRange get_row_partition(const int rank, const unsigned idx=0u) const;
     const std::vector<ColumnRange> get_sorted_column_partitions() const { return m_sorted_column_partitions; }
-    void read_and_initialize_vid_and_callset_mapping_if_available(FileBasedVidMapper* id_mapper, const int rank);
+    void read_and_initialize_vid_and_callset_mapping_if_available(VidMapper* id_mapper, const int rank);
     const std::vector<ColumnRange>& get_query_column_ranges(const int rank) const;
     const std::vector<RowRange>& get_query_row_ranges(const int rank) const;
   protected:
@@ -110,7 +111,7 @@ class JSONBasicQueryConfig : public JSONConfigBase
 {
   public:
     JSONBasicQueryConfig() : JSONConfigBase()  { }
-    void read_from_file(const std::string& filename, VariantQueryConfig& query_config, FileBasedVidMapper* id_mapper=0, int rank=0, JSONLoaderConfig* loader_config=0);
+    void read_from_file(const std::string& filename, VariantQueryConfig& query_config, VidMapper* id_mapper=0, int rank=0, JSONLoaderConfig* loader_config=0);
     void update_from_loader(JSONLoaderConfig* loader_config, const int rank);
     void subset_query_column_ranges_based_on_partition(const JSONLoaderConfig* loader_config, const int rank);
 };
@@ -122,7 +123,7 @@ class JSONLoaderConfig : public JSONConfigBase
 {
   public:
     JSONLoaderConfig(bool vid_mapper_file_required = true);
-    void read_from_file(const std::string& filename, FileBasedVidMapper* id_mapper=0, int rank=0);
+    void read_from_file(const std::string& filename, VidMapper* id_mapper=0, int rank=0);
     inline bool is_partitioned_by_row() const { return m_row_based_partitioning; }
     inline bool is_partitioned_by_column() const { return !m_row_based_partitioning; }
     inline ColumnRange get_column_partition(int idx) const
@@ -148,6 +149,7 @@ class JSONLoaderConfig : public JSONConfigBase
     inline bool consolidate_tiledb_array_after_load() const { return m_consolidate_tiledb_array_after_load; }
     inline bool discard_missing_GTs() const { return m_discard_missing_GTs; }
     inline bool no_mandatory_VCF_fields() const { return m_no_mandatory_VCF_fields; }
+    inline bool treat_deletions_as_intervals() const { return m_treat_deletions_as_intervals; }
   protected:
     bool m_standalone_converter_process;
     bool m_treat_deletions_as_intervals;
@@ -204,7 +206,9 @@ class JSONVCFAdapterConfig : public JSONConfigBase
       m_combined_vcf_records_buffer_size_limit = DEFAULT_COMBINED_VCF_RECORDS_BUFFER_SIZE;
     }
     void read_from_file(const std::string& filename,
-        VCFAdapter& vcf_adapter, std::string output_format="", int rank=0,
+        VCFAdapter& vcf_adapter,
+        VidMapper* id_mapper,
+        std::string output_format="", int rank=0,
         const size_t combined_vcf_records_buffer_size_limit=0u);
     inline unsigned get_determine_sites_with_max_alleles() const { return m_determine_sites_with_max_alleles; }
     inline unsigned get_max_diploid_alt_alleles_that_can_be_genotyped() const { return m_max_diploid_alt_alleles_that_can_be_genotyped; }
@@ -226,7 +230,7 @@ class JSONVCFAdapterQueryConfig : public JSONVCFAdapterConfig, public JSONBasicQ
   public:
     JSONVCFAdapterQueryConfig() : JSONVCFAdapterConfig(), JSONBasicQueryConfig() { ; }
     void read_from_file(const std::string& filename, VariantQueryConfig& query_config,
-        VCFAdapter& vcf_adapter, FileBasedVidMapper* id_mapper,
+        VCFAdapter& vcf_adapter, VidMapper* id_mapper,
         std::string output_format="", int rank=0,
         const size_t combined_vcf_records_buffer_size_limit=0u);
 };

--- a/src/main/cpp/src/loader/load_operators.cc
+++ b/src/main/cpp/src/loader/load_operators.cc
@@ -120,6 +120,7 @@ LoaderArrayWriter::LoaderArrayWriter(
         config_filename,
         id_mapper->get_num_callsets(),
         rank,
+        id_mapper,
         vid_mapper_file_required),
         m_array_descriptor(-1),
         m_schema(0),
@@ -308,14 +309,18 @@ void LoaderArrayWriter::finish(const int64_t column_interval_end)
 }
 
 #ifdef HTSDIR
-LoaderCombinedGVCFOperator::LoaderCombinedGVCFOperator(const VidMapper* id_mapper, const std::string& config_filename,
-    bool handle_spanning_deletions, int partition_idx, const ColumnRange& partition_range)
-  : LoaderOperatorBase(config_filename, id_mapper->get_num_callsets(), partition_idx), m_schema(0), m_query_processor(0), m_operator(0)
+LoaderCombinedGVCFOperator::LoaderCombinedGVCFOperator(const VidMapper* id_mapper,
+    const std::string& config_filename,
+    int partition_idx,
+    const bool vid_mapper_file_required)
+  : LoaderOperatorBase(config_filename,
+      id_mapper->get_num_callsets(),
+      partition_idx,
+      id_mapper,
+      vid_mapper_file_required),
+  m_schema(0), m_query_processor(0), m_operator(0)
 {
   clear(); 
-  //Loader configuration
-  if(!m_loader_json_config.is_partitioned_by_row())
-    m_column_partition = m_loader_json_config.get_column_partition(partition_idx);
   //initialize arguments
   m_vid_mapper = id_mapper;
   //initialize query processor
@@ -343,7 +348,10 @@ LoaderCombinedGVCFOperator::LoaderCombinedGVCFOperator(const VidMapper* id_mappe
     m_buffered_vcf_adapter = 0;
   }
   JSONVCFAdapterConfig vcf_adapter_config;
-  vcf_adapter_config.read_from_file(config_filename, *m_vcf_adapter, "", partition_idx);
+  VidMapper tmp_vid_mapper;
+  if(m_vid_mapper)
+    tmp_vid_mapper = *m_vid_mapper;
+  vcf_adapter_config.read_from_file(config_filename, *m_vcf_adapter, &tmp_vid_mapper, "", partition_idx);
   //Initialize operator
   if(vcf_adapter_config.get_determine_sites_with_max_alleles() > 0)
     m_operator = new MaxAllelesCountOperator(vcf_adapter_config.get_determine_sites_with_max_alleles());
@@ -355,8 +363,6 @@ LoaderCombinedGVCFOperator::LoaderCombinedGVCFOperator(const VidMapper* id_mappe
   m_variant.resize_based_on_query();
   //Cell
   m_cell = new BufferVariantCell(*m_schema, m_query_config);
-  //Partition bounds
-  m_partition = partition_range;
   //PQ elements
   m_tmp_pq_vector.resize(m_query_config.get_num_rows_to_query());
   //Position elements
@@ -364,7 +370,6 @@ LoaderCombinedGVCFOperator::LoaderCombinedGVCFOperator(const VidMapper* id_mappe
   m_next_start_position = -1ll;
   //Deletion flags
   m_num_calls_with_deletions = 0;
-  m_handle_spanning_deletions = handle_spanning_deletions;
   //Profiling
 #ifdef DO_PROFILING
   m_stats_ptr = &m_stats;
@@ -402,15 +407,15 @@ void LoaderCombinedGVCFOperator::operate(const void* cell_ptr)
       return;
   }
   //Either un-initialized or VariantCall interval starts before/at partition begin value
-  if(m_current_start_position < 0 || column_begin <= m_partition.first)
+  if(m_current_start_position < 0 || column_begin <= m_column_partition.first)
   {
     m_current_start_position = column_begin;
     m_variant.set_column_interval(column_begin, column_begin);
   }
-  else  //column_begin > m_partition.first, check if m_current_start_position < m_partition.first
-    if(m_current_start_position < m_partition.first)
+  else  //column_begin > m_column_partition.first, check if m_current_start_position < m_column_partition.first
+    if(m_current_start_position < m_column_partition.first)
     {
-      m_current_start_position = m_partition.first;
+      m_current_start_position = m_column_partition.first;
       m_variant.set_column_interval(m_current_start_position, m_current_start_position);
     }
   m_cell->set_cell(cell_ptr);
@@ -418,7 +423,8 @@ void LoaderCombinedGVCFOperator::operate(const void* cell_ptr)
       m_variant, *m_operator, *m_cell,
       m_end_pq, m_tmp_pq_vector,
       m_current_start_position, m_next_start_position,
-      m_num_calls_with_deletions, m_handle_spanning_deletions,
+      m_num_calls_with_deletions,
+      m_loader_json_config.treat_deletions_as_intervals(),
       m_stats_ptr);
 #ifdef DO_MEMORY_PROFILING
   statm_t mem_result;
@@ -438,9 +444,9 @@ void LoaderCombinedGVCFOperator::finish(const int64_t column_interval_end)
   assert(!m_offload_vcf_output_processing || m_buffered_vcf_adapter->get_num_entries_with_valid_data() == 0u);
   pre_operate_sequential();
   //Fix start and next_start positions if necessary
-  if(m_current_start_position < m_partition.first)
+  if(m_current_start_position < m_column_partition.first)
   {
-    m_current_start_position = m_partition.first;
+    m_current_start_position = m_column_partition.first;
     m_variant.set_column_interval(m_current_start_position, m_current_start_position);
   }
   m_next_start_position = (column_interval_end == INT64_MAX) ? INT64_MAX : column_interval_end+1;

--- a/src/main/cpp/src/loader/tiledb_loader.cc
+++ b/src/main/cpp/src/loader/tiledb_loader.cc
@@ -68,7 +68,6 @@ VCF2TileDBLoaderConverterBase::VCF2TileDBLoaderConverterBase(
 {
   clear();
   m_idx = idx;
-  JSONLoaderConfig::read_from_file(config_filename, 0, m_idx);
   //Override
   m_lb_callset_row_idx = std::max(lb_callset_row_idx, m_lb_callset_row_idx);
   m_ub_callset_row_idx = std::min(ub_callset_row_idx, m_ub_callset_row_idx);
@@ -188,6 +187,8 @@ VCF2TileDBConverter::VCF2TileDBConverter(
     m_exchanges.resize(exchange_vector->size());
     for(auto i=0u;i<m_exchanges.size();++i)
       m_exchanges[i] = &((*exchange_vector)[i]);
+    VidMapper tmp_vid_mapper = *m_vid_mapper;
+    JSONLoaderConfig::read_from_file(config_filename, &tmp_vid_mapper, m_idx);
   }
   determine_num_callsets_owned(m_vid_mapper, false);
   m_max_size_per_callset = m_per_partition_size/m_num_orders_owned;
@@ -573,7 +574,9 @@ void VCF2TileDBLoader::common_constructor_initialization(
           callsetmap_pb,
           buffer_stream_info_vec));
     m_vid_mapper_file_required = false;
+    JSONLoaderConfig::read_from_file(config_filename, m_vid_mapper, m_idx);
   } else {
+    JSONLoaderConfig::read_from_file(config_filename, 0, m_idx);
     m_vid_mapper = static_cast<VidMapper*>(
         new FileBasedVidMapper(
           m_vid_mapping_file,
@@ -642,8 +645,11 @@ void VCF2TileDBLoader::common_constructor_initialization(
 #ifdef HTSDIR
     //Operators
     m_operators.push_back(dynamic_cast<LoaderOperatorBase*>(
-          new LoaderCombinedGVCFOperator(m_vid_mapper, config_filename, m_treat_deletions_as_intervals, m_idx,
-            get_column_partition())));
+          new LoaderCombinedGVCFOperator(
+            m_vid_mapper,
+            config_filename,
+            m_idx,
+            m_vid_mapper_file_required)));
     m_operators_overflow.push_back(false);
 #else
     throw VCF2TileDBException("To produce VCFs, you need the htslib library - recompile with HTSDIR set");

--- a/src/main/cpp/src/utils/json_config.cc
+++ b/src/main/cpp/src/utils/json_config.cc
@@ -226,9 +226,10 @@ void JSONConfigBase::read_from_file(const std::string& filename, const VidMapper
     }
   }
   //Array
-  if(m_json.HasMember("array"))
+  VERIFY_OR_THROW(!(m_json.HasMember("array") && m_json.HasMember("array_name")));
+  if(m_json.HasMember("array") || m_json.HasMember("array_name"))
   {
-    const rapidjson::Value& array_name = m_json["array"];
+    const rapidjson::Value& array_name = m_json.HasMember("array") ? m_json["array"] : m_json["array_name"];
     //array could be an array, one array dir for every rank
     if(array_name.IsArray())
     {
@@ -383,11 +384,15 @@ void JSONConfigBase::read_from_file(const std::string& filename, const VidMapper
             m_workspaces[partition_idx] = curr_partition_info_dict["workspace"].GetString();
             m_single_workspace_path = false;
           }
-          if(curr_partition_info_dict.HasMember("array"))
+          if(curr_partition_info_dict.HasMember("array") || curr_partition_info_dict.HasMember("array_name"))
           {
+            VERIFY_OR_THROW(!(curr_partition_info_dict.HasMember("array")
+                  && curr_partition_info_dict.HasMember("array_name")));
             if(column_partitions_array.Size() >= m_array_names.size())
               m_array_names.resize(column_partitions_array.Size(), array_name_string);
-            m_array_names[partition_idx] = curr_partition_info_dict["array"].GetString();
+            m_array_names[partition_idx] = curr_partition_info_dict.HasMember("array")
+              ? curr_partition_info_dict["array"].GetString()
+              : curr_partition_info_dict["array_name"].GetString();
             m_single_array_name = false;
           }
           //Mapping from begin pos to index
@@ -492,11 +497,15 @@ void JSONConfigBase::read_from_file(const std::string& filename, const VidMapper
             m_workspaces[partition_idx] = curr_partition_info_dict["workspace"].GetString();
             m_single_workspace_path = false;
           }
-          if(curr_partition_info_dict.HasMember("array"))
+          if(curr_partition_info_dict.HasMember("array") || curr_partition_info_dict.HasMember("array_name"))
           {
+            VERIFY_OR_THROW(!(curr_partition_info_dict.HasMember("array")
+                  && curr_partition_info_dict.HasMember("array_name")));
             if(row_partitions_array.Size() >= m_array_names.size())
               m_array_names.resize(row_partitions_array.Size(), array_name_string);
-            m_array_names[partition_idx] = curr_partition_info_dict["array"].GetString();
+            m_array_names[partition_idx] = curr_partition_info_dict.HasMember("array")
+              ? curr_partition_info_dict["array"].GetString()
+              : curr_partition_info_dict["array_name"].GetString();
             m_single_array_name = false;
           }
           //Mapping from begin pos to index
@@ -649,7 +658,7 @@ void JSONBasicQueryConfig::update_from_loader(JSONLoaderConfig* loader_config, c
     m_workspaces.push_back(loader_config->get_workspace(rank));
   }
   // Update array if it is not provided in query json
-  if (!m_json.HasMember("array"))
+  if (!(m_json.HasMember("array") || m_json.HasMember("array_name")))
   {
     // Set as single array
     m_single_array_name = true;

--- a/src/main/java/com/intel/genomicsdb/Constants.java
+++ b/src/main/java/com/intel/genomicsdb/Constants.java
@@ -1,0 +1,12 @@
+package com.intel.genomicsdb;
+
+public final class Constants {
+
+    private Constants() {
+    }
+
+    public static final String CHROMOSOME_FOLDER_DELIMITER_SYMBOL = "$";
+    public static final String CHROMOSOME_FOLDER_DELIMITER_SYMBOL_REGEX = "\\$";
+    public static final String CHROMOSOME_INTERVAL_FOLDER = String.format("%%s%s%%d%s%%d",
+            CHROMOSOME_FOLDER_DELIMITER_SYMBOL, CHROMOSOME_FOLDER_DELIMITER_SYMBOL);
+}

--- a/src/main/java/com/intel/genomicsdb/importer/Constants.java
+++ b/src/main/java/com/intel/genomicsdb/importer/Constants.java
@@ -22,6 +22,5 @@ public final class Constants {
     public static final HashSet<String> R_LENGTH_TWO_DIM_INT_VECTOR_FIELDS = new HashSet<>(Collections.singletonList(
             "AS_SB_TABLE"
     ));
-    public static final String CHROMOSOME_INTERVAL_FOLDER = "%s#%d#%d";
     public static final long DEFAULT_BUFFER_CAPACITY = 20480; //20KB
 }

--- a/src/main/java/com/intel/genomicsdb/importer/GenomicsDBImporter.java
+++ b/src/main/java/com/intel/genomicsdb/importer/GenomicsDBImporter.java
@@ -479,12 +479,14 @@ public class GenomicsDBImporter extends GenomicsDBImporterJni implements JsonFil
         }
     }
 
-    //TODO: this is going to be private access and after that should write in parallel.
+    //This should be public because there can be use cases where iterator<VariantContext>
+    //are not used - the data is written to buffers directly after which this function is
+    //called. See TestBufferStreamGenomicsDBImporter.java for an example
     /**
      * @return true if the import process is done
-     * @throws IOException if the wimport fails
+     * @throws IOException if the import fails
      */
-    private boolean executeSingleImport() throws IOException {
+    public boolean executeSingleImport() throws IOException {
         if (mDone)
             return true;
         if (!mIsLoaderSetupDone)

--- a/src/main/java/com/intel/genomicsdb/importer/GenomicsDBImporter.java
+++ b/src/main/java/com/intel/genomicsdb/importer/GenomicsDBImporter.java
@@ -48,6 +48,7 @@ import java.util.concurrent.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static com.intel.genomicsdb.Constants.CHROMOSOME_INTERVAL_FOLDER;
 import static com.intel.genomicsdb.importer.Constants.*;
 
 /**

--- a/src/main/java/com/intel/genomicsdb/importer/GenomicsDBImporter.java
+++ b/src/main/java/com/intel/genomicsdb/importer/GenomicsDBImporter.java
@@ -611,9 +611,12 @@ public class GenomicsDBImporter extends GenomicsDBImporterJni implements JsonFil
                 .getContigPosition().getPosition();
         int chromosomeEnd = (int) importConfig.getImportConfiguration().getColumnPartitions(rank).getEnd()
                 .getContigPosition().getPosition();
-        String arrayName = String.format(CHROMOSOME_INTERVAL_FOLDER, chromosomeName, chromosomeStart, chromosomeEnd);
         GenomicsDBImportConfiguration.Partition partition = importConfig.getImportConfiguration()
-                .getColumnPartitions(rank).toBuilder().setArray(arrayName).build();
+            .getColumnPartitions(rank);
+        if(partition.hasGenerateArrayNameFromPartitionBounds()) {
+            String arrayName = String.format(CHROMOSOME_INTERVAL_FOLDER, chromosomeName, chromosomeStart, chromosomeEnd);
+            partition = partition.toBuilder().setArrayName(arrayName).build();
+        }
         GenomicsDBImportConfiguration.ImportConfiguration importConfiguration = importConfig
                 .getImportConfiguration().toBuilder()
                 .setLbCallsetRowIdx((long) index)

--- a/src/main/java/com/intel/genomicsdb/importer/GenomicsDBImporter.java
+++ b/src/main/java/com/intel/genomicsdb/importer/GenomicsDBImporter.java
@@ -588,12 +588,16 @@ public class GenomicsDBImporter extends GenomicsDBImporterJni implements JsonFil
         }
 
         executor.shutdown();
+
+        mDone = true;
     }
 
-    private static GenomicsDBImporter createImporter(ParallelImportConfig parallelImportConfig,
+    private static GenomicsDBImporter createImporter(final ParallelImportConfig inputParallelImportConfig,
                                                      final int samplesSize, final int index,
                                                      final Map<String, FeatureReader<VariantContext>> sampleToReaderMap,
                                                      final int rank) throws IOException {
+        //since this may be called in a multi-threaded env, do a deep copy
+        ParallelImportConfig parallelImportConfig = new ParallelImportConfig(inputParallelImportConfig);
         String chromosomeName = parallelImportConfig.getImportConfiguration().getColumnPartitions(rank).getBegin().getContigPosition().getContig();
         int chromosomeStart = (int) parallelImportConfig.getImportConfiguration().getColumnPartitions(rank).getBegin().getContigPosition().getPosition();
         int chromosomeEnd = (int) parallelImportConfig.getImportConfiguration().getColumnPartitions(rank).getEnd().getContigPosition().getPosition();

--- a/src/main/java/com/intel/genomicsdb/importer/GenomicsDBImporter.java
+++ b/src/main/java/com/intel/genomicsdb/importer/GenomicsDBImporter.java
@@ -479,10 +479,9 @@ public class GenomicsDBImporter extends GenomicsDBImporterJni implements JsonFil
         }
     }
 
-    //This should be public because there can be use cases where iterator<VariantContext>
-    //are not used - the data is written to buffers directly after which this function is
-    //called. See TestBufferStreamGenomicsDBImporter.java for an example
     /**
+     * Only to be used in cases where iterator<VariantContext> are not used. The data is written to buffers
+     * directly after which this function is called. See TestBufferStreamGenomicsDBImporter.java for an example
      * @return true if the import process is done
      * @throws IOException if the import fails
      */

--- a/src/main/java/com/intel/genomicsdb/model/CommandLineImportConfig.java
+++ b/src/main/java/com/intel/genomicsdb/model/CommandLineImportConfig.java
@@ -18,7 +18,7 @@ import java.util.stream.IntStream;
 
 import static java.util.stream.Collectors.toList;
 
-public class CommandLineImportConfig extends ParallelImportConfig {
+public class CommandLineImportConfig extends ImportConfig {
     //TODO: remove this constant once C++ layer makes use of protobuf structures
     protected static final long DEFAULT_SIZE_PER_COLUMN_PARTITION = 16384L;
     private GenomicsDBImportConfiguration.ImportConfiguration.Builder configurationBuilder =

--- a/src/main/java/com/intel/genomicsdb/model/CommandLineImportConfig.java
+++ b/src/main/java/com/intel/genomicsdb/model/CommandLineImportConfig.java
@@ -1,8 +1,5 @@
 package com.intel.genomicsdb.model;
 
-import com.google.protobuf.UninitializedMessageException;
-import com.intel.genomicsdb.importer.model.ChromosomeInterval;
-import com.intel.genomicsdb.model.coordinates;
 import gnu.getopt.Getopt;
 import gnu.getopt.LongOpt;
 import htsjdk.tribble.AbstractFeatureReader;
@@ -16,7 +13,7 @@ import htsjdk.variant.vcf.VCFUtils;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
-import java.util.function.Function;
+import java.util.function.Consumer;
 import java.util.stream.IntStream;
 
 import static java.util.stream.Collectors.toList;
@@ -24,42 +21,42 @@ import static java.util.stream.Collectors.toList;
 public class CommandLineImportConfig extends ParallelImportConfig {
     //TODO: remove this constant once C++ layer makes use of protobuf structures
     protected static final long DEFAULT_SIZE_PER_COLUMN_PARTITION = 16384L;
-    GenomicsDBImportConfiguration.Partition.Builder partitionBuilder =
-            GenomicsDBImportConfiguration.Partition.newBuilder();
-    GenomicsDBImportConfiguration.ImportConfiguration.Builder configurationBuilder =
+    private GenomicsDBImportConfiguration.ImportConfiguration.Builder configurationBuilder =
             GenomicsDBImportConfiguration.ImportConfiguration.newBuilder();
+    private List<GenomicsDBImportConfiguration.Partition.Builder> partitionList = new ArrayList<>();
+    private String workspace = "";
+    private String vcfOutputFilename = "";
+    private Consumer<String[]> chromInterToPartitionList = par -> {
+        GenomicsDBImportConfiguration.Partition.Builder partitionBuilder = GenomicsDBImportConfiguration.Partition.newBuilder();
+        Coordinates.ContigPosition.Builder contigPositionBuilder = Coordinates.ContigPosition.newBuilder();
+        Coordinates.GenomicsDBColumn.Builder columnBuilder = Coordinates.GenomicsDBColumn.newBuilder();
+        //begin
+        contigPositionBuilder.setContig(par[0]).setPosition(Long.parseLong(par[1].split("-")[0]));
+        columnBuilder.setContigPosition(contigPositionBuilder.build());
+        partitionBuilder.setBegin(columnBuilder.build());
+        //end
+        contigPositionBuilder.setPosition(Long.parseLong(par[1].split("-")[1]));
+        columnBuilder.setContigPosition(contigPositionBuilder.build());
+        partitionBuilder.setEnd(columnBuilder.build());
+        partitionList.add(partitionBuilder);
+    };
 
     public CommandLineImportConfig(final String command, final String[] commandArgs) {
         Getopt getOpt = new Getopt(command, commandArgs, "w:A:L:", resolveLongOpt());
-        this.validateChromosomeIntervals(this.getChromosomeIntervalList());
-        int numPositionalArgs = commandArgs.length - getOpt.getOptind();
-        if (numPositionalArgs <= 0
-                || this.getImportConfiguration().getColumnPartitions(0).getWorkspace().isEmpty()
-                || this.getChromosomeIntervalList().isEmpty()) {
-            throwIllegalArgumentException();
-        }
         //TODO: remove next line once C++ layer makes use of protobuf structures. Making size per column partition explicit.
         configurationBuilder.setSizePerColumnPartition(DEFAULT_SIZE_PER_COLUMN_PARTITION);
         resolveCommandArgs(getOpt);
-        try {
-            for(ChromosomeInterval currInterval : this.getChromosomeIntervalList()) {
-                coordinates.ContigPosition.Builder contigPositionBuilder =
-                    coordinates.ContigPosition.newBuilder();
-                coordinates.GenomicsDBColumn.Builder columnBuilder =
-                    coordinates.GenomicsDBColumn.newBuilder();
-                //begin
-                contigPositionBuilder.setContig(currInterval.getContig())
-                    .setPosition(currInterval.getStart());
-                columnBuilder.setContigPosition(contigPositionBuilder.build());
-                partitionBuilder.setBegin(columnBuilder.build());
-                //end
-                contigPositionBuilder.setPosition(currInterval.getEnd());
-                columnBuilder.setContigPosition(contigPositionBuilder.build());
-                partitionBuilder.setEnd(columnBuilder.build());
-                configurationBuilder.addColumnPartitions(partitionBuilder.build());
-            }
-            this.setImportConfiguration(configurationBuilder.build());
-        } catch (UninitializedMessageException ex) {
+        partitionList.forEach(partition -> {
+                    partition.setWorkspace(this.workspace);
+                    if (!vcfOutputFilename.isEmpty()) partition.setVcfOutputFilename(vcfOutputFilename);
+                });
+        partitionList.forEach(partition -> configurationBuilder.addColumnPartitions(partition));
+        this.setImportConfiguration(configurationBuilder.build());
+        this.validateChromosomeIntervals();
+        int numPositionalArgs = commandArgs.length - getOpt.getOptind();
+        if (numPositionalArgs <= 0
+                || this.getImportConfiguration().getColumnPartitions(0).getWorkspace().isEmpty()
+                || this.getImportConfiguration().getColumnPartitionsList().isEmpty()) {
             throwIllegalArgumentException();
         }
         List<String> files = IntStream.range(getOpt.getOptind(), commandArgs.length).mapToObj(
@@ -100,13 +97,10 @@ public class CommandLineImportConfig extends ParallelImportConfig {
         while ((c = commandArgs.getopt()) != -1) {
             switch (c) {
                 case 'w':
-                    partitionBuilder.setWorkspace(commandArgs.getOptarg());
+                    workspace = commandArgs.getOptarg();
                     break;
                 case 'L':
-                    Function<String[], ChromosomeInterval> chromInterConverter = par -> new ChromosomeInterval(par[0],
-                            Long.parseLong(par[1].split("-")[0]),
-                            Long.parseLong(par[1].split("-")[1]));
-                    this.getChromosomeIntervalList().add(chromInterConverter.apply(commandArgs.getOptarg().split(":")));
+                    chromInterToPartitionList.accept(commandArgs.getOptarg().split(":"));
                     break;
                 default: {
                     if (c >= firstEnumIdx && c < ArgsIdxEnum.ARGS_IDX_AFTER_LAST_ARG_IDX.idx()) {
@@ -129,7 +123,7 @@ public class CommandLineImportConfig extends ParallelImportConfig {
                                 this.setOutputCallsetmapJsonFile(commandArgs.getOptarg());
                                 break;
                             case ARGS_IDX_VCF_HEADER_OUTPUT:
-                                partitionBuilder.setVcfOutputFilename(commandArgs.getOptarg());
+                                vcfOutputFilename = commandArgs.getOptarg();
                                 break;
                             case ARGS_IDX_PASS_AS_BCF:
                                 setPassAsVcf(false);

--- a/src/main/java/com/intel/genomicsdb/model/CommandLineImportConfig.java
+++ b/src/main/java/com/intel/genomicsdb/model/CommandLineImportConfig.java
@@ -25,6 +25,7 @@ public class CommandLineImportConfig extends ImportConfig {
             GenomicsDBImportConfiguration.ImportConfiguration.newBuilder();
     private List<GenomicsDBImportConfiguration.Partition.Builder> partitionList = new ArrayList<>();
     private String workspace = "";
+    private String array = "";
     private String vcfOutputFilename = "";
     private Consumer<String[]> chromInterToPartitionList = par -> {
         GenomicsDBImportConfiguration.Partition.Builder partitionBuilder = GenomicsDBImportConfiguration.Partition.newBuilder();
@@ -48,6 +49,10 @@ public class CommandLineImportConfig extends ImportConfig {
         resolveCommandArgs(getOpt);
         partitionList.forEach(partition -> {
                     partition.setWorkspace(this.workspace);
+                    if(array.isEmpty())
+                         partition.setGenerateArrayNameFromPartitionBounds(true);
+                    else
+                         partition.setArrayName(array);
                     if (!vcfOutputFilename.isEmpty()) partition.setVcfOutputFilename(vcfOutputFilename);
                 });
         partitionList.forEach(partition -> configurationBuilder.addColumnPartitions(partition));
@@ -66,7 +71,7 @@ public class CommandLineImportConfig extends ImportConfig {
     }
 
     private LongOpt[] resolveLongOpt() {
-        LongOpt[] longopts = new LongOpt[11];
+        LongOpt[] longopts = new LongOpt[12];
         longopts[0] = new LongOpt("use_samples_in_order", LongOpt.NO_ARGUMENT, null,
                 ArgsIdxEnum.ARGS_IDX_USE_SAMPLES_IN_ORDER.idx());
         longopts[1] = new LongOpt("fail_if_updating", LongOpt.NO_ARGUMENT, null,
@@ -87,6 +92,7 @@ public class CommandLineImportConfig extends ImportConfig {
                 ArgsIdxEnum.ARGS_IDX_SIZE_PER_COLUMN_PARTITION.idx());
         longopts[10] = new LongOpt("segment_size", LongOpt.REQUIRED_ARGUMENT, null,
                 ArgsIdxEnum.ARGS_IDX_SEGMENT_SIZE.idx());
+        longopts[11] = new LongOpt("array", LongOpt.REQUIRED_ARGUMENT, null, 'A');
         return longopts;
     }
 
@@ -98,6 +104,9 @@ public class CommandLineImportConfig extends ImportConfig {
             switch (c) {
                 case 'w':
                     workspace = commandArgs.getOptarg();
+                    break;
+                case 'A':
+                    array = commandArgs.getOptarg();
                     break;
                 case 'L':
                     chromInterToPartitionList.accept(commandArgs.getOptarg().split(":"));
@@ -148,7 +157,7 @@ public class CommandLineImportConfig extends ImportConfig {
 
     private void throwIllegalArgumentException() {
         throw new IllegalArgumentException("Invalid usage. Correct way of using arguments: -L chromosome:interval " +
-                "-w genomicsdbworkspace --size_per_column_partition 10000 --segment_size 1048576 variantfile(s) " +
+                "-w genomicsdbworkspace [-A array] --size_per_column_partition 10000 --segment_size 1048576 variantfile(s) " +
                 "[--use_samples_in_order --fail_if_updating --batchsize=<N> --vidmap-output <path>]");
     }
 

--- a/src/main/java/com/intel/genomicsdb/model/ImportConfig.java
+++ b/src/main/java/com/intel/genomicsdb/model/ImportConfig.java
@@ -74,33 +74,6 @@ public class ImportConfig {
         this.setSampleToReaderMapCreator(sampleToReaderMapCreator);
     }
 
-    /**
-     * Deep copy constructor
-     * @param source Source ImportConfig
-     */
-    public ImportConfig(final ImportConfig source) {
-        this.setImportConfiguration(source.getImportConfiguration() != null ?
-                source.getImportConfiguration().toBuilder().build() : null);
-        this.validateChromosomeIntervals();
-        this.setValidateSampleToReaderMap(source.isValidateSampleToReaderMap());
-        this.setPassAsVcf(source.isPassAsVcf());
-        this.setUseSamplesInOrder(source.isUseSamplesInOrder());
-        this.setBatchSize(source.getBatchSize());
-        //Cannot deep copy mergedHeader easily - so do shallow copy and make it unmodifiable
-        this.setMergedHeader(source.getMergedHeader());
-        //Deep copy sample name to path
-        if(source.getSampleNameToVcfPath() != null) {
-            this.setSampleNameToVcfPath(new LinkedHashMap<>(source.getSampleNameToVcfPath()));
-        }
-        //Function object - no deep copy
-        this.setSampleToReaderMapCreator(source.sampleToReaderMapCreator());
-        //Deep copy
-        this.setOutputVidmapJsonFile(source.getOutputVidmapJsonFile() != null ?
-                new String(source.getOutputVidmapJsonFile()) : null);
-        this.setOutputCallsetmapJsonFile(source.getOutputCallsetmapJsonFile() != null ?
-                new String(source.getOutputCallsetmapJsonFile()) : null);
-    }
-
     protected ImportConfig() {
     }
 

--- a/src/main/java/com/intel/genomicsdb/model/ParallelImportConfig.java
+++ b/src/main/java/com/intel/genomicsdb/model/ParallelImportConfig.java
@@ -61,6 +61,35 @@ public class ParallelImportConfig {
         this.setSampleToReaderMapCreator(sampleToReaderMapCreator);
     }
 
+    //Deep copy constructor
+    public ParallelImportConfig(final ParallelImportConfig source) {
+        this.setImportConfiguration(
+                source.getImportConfiguration() != null
+                ? source.getImportConfiguration().toBuilder().build()
+                : null);
+        this.validateChromosomeIntervals();
+        this.setValidateSampleToReaderMap(source.isValidateSampleToReaderMap());
+        this.setPassAsVcf(source.isPassAsVcf());
+        this.setUseSamplesInOrder(source.isUseSamplesInOrder());
+        this.setBatchSize(source.getBatchSize());
+        //Cannot deep copy mergedHeader easily - so do shallow copy and make it unmodifiable
+        this.setMergedHeader(source.getMergedHeader());
+        //Deep copy sample name to path
+        if(source.getSampleNameToVcfPath() != null) {
+            LinkedHashMap<String, Path> sampleNameToVcfPath = new LinkedHashMap<String, Path>();
+            for(Map.Entry<String, Path> currEntry : source.getSampleNameToVcfPath().entrySet())
+                sampleNameToVcfPath.put(currEntry.getKey(), currEntry.getValue());
+            this.setSampleNameToVcfPath(sampleNameToVcfPath);
+        }
+        //Function object - no deep copy
+        this.setSampleToReaderMapCreator(source.sampleToReaderMapCreator());
+        //Deep copy
+        this.setOutputVidmapJsonFile(source.getOutputVidmapJsonFile() != null
+                ? new String(source.getOutputVidmapJsonFile()): null);
+        this.setOutputCallsetmapJsonFile(source.getOutputCallsetmapJsonFile() != null
+                ? new String(source.getOutputCallsetmapJsonFile()): null);
+    }
+
     protected ParallelImportConfig() {
     }
 
@@ -161,7 +190,7 @@ public class ParallelImportConfig {
     }
 
     public Set<VCFHeaderLine> getMergedHeader() {
-        return mergedHeader;
+        return Collections.unmodifiableSet(mergedHeader);
     }
 
     public void setMergedHeader(Set<VCFHeaderLine> mergedHeader) {

--- a/src/main/java/com/intel/genomicsdb/model/ParallelImportConfig.java
+++ b/src/main/java/com/intel/genomicsdb/model/ParallelImportConfig.java
@@ -29,17 +29,22 @@ import htsjdk.variant.vcf.VCFHeaderLine;
 
 import java.nio.file.Path;
 import java.util.*;
+import java.lang.Integer;
 
 public class ParallelImportConfig {
     private GenomicsDBImportConfiguration.ImportConfiguration importConfiguration;
     private List<ChromosomeInterval> chromosomeIntervalList = new ArrayList<>();
     private int rank = 0;
-    private boolean validateSampleToReaderMap;
+    private boolean validateSampleToReaderMap = false;
     private boolean passAsVcf = true;
-    private int batchSize = 1000000;
+    private boolean useSamplesInOrder = false;
+    private int batchSize = Integer.MAX_VALUE;
     private Set<VCFHeaderLine> mergedHeader;
     private Map<String, Path> sampleNameToVcfPath;
-    private Func<Map<String, Path>, Integer, Integer, Map<String, FeatureReader<VariantContext>>> sampleToReaderMap;
+    private Func<Map<String, Path>, Integer, Integer, Map<String, FeatureReader<VariantContext>>> sampleToReaderMapCreator;
+    private String outputVidMapJsonFile = null;
+    private String outputCallsetMapJsonFile = null;
+
 
     public ParallelImportConfig(final GenomicsDBImportConfiguration.ImportConfiguration importConfiguration,
                                 final List<ChromosomeInterval> chromosomeIntervalList,
@@ -50,7 +55,7 @@ public class ParallelImportConfig {
                                 final Set<VCFHeaderLine> mergedHeader,
                                 final Map<String, Path> sampleNameToVcfPath,
                                 final Func<Map<String, Path>, Integer, Integer,
-                                    Map<String, FeatureReader<VariantContext>>> sampleToReaderMap) {
+                                    Map<String, FeatureReader<VariantContext>>> sampleToReaderMapCreator) {
         this.setImportConfiguration(importConfiguration);
         this.setChromosomeIntervalList(chromosomeIntervalList);
         this.setRank(rank);
@@ -59,7 +64,7 @@ public class ParallelImportConfig {
         this.setBatchSize(batchSize);
         this.setMergedHeader(mergedHeader);
         this.setSampleNameToVcfPath(sampleNameToVcfPath);
-        this.setSampleToReaderMap(sampleToReaderMap);
+        this.setSampleToReaderMapCreator(sampleToReaderMapCreator);
     }
 
     protected ParallelImportConfig() {
@@ -119,11 +124,12 @@ public class ParallelImportConfig {
     }
 
     public Func<Map<String, Path>, Integer, Integer, Map<String, FeatureReader<VariantContext>>> sampleToReaderMapCreator() {
-        return sampleToReaderMap;
+        return sampleToReaderMapCreator;
     }
 
-    public void setSampleToReaderMap(Func<Map<String, Path>, Integer, Integer, Map<String, FeatureReader<VariantContext>>> sampleToReaderMap) {
-        this.sampleToReaderMap = sampleToReaderMap;
+    public void setSampleToReaderMapCreator(
+            Func<Map<String, Path>, Integer, Integer, Map<String, FeatureReader<VariantContext>>> sampleToReaderMapCreator) {
+        this.sampleToReaderMapCreator = sampleToReaderMapCreator;
     }
 
     public List<ChromosomeInterval> getChromosomeIntervalList() {
@@ -140,6 +146,10 @@ public class ParallelImportConfig {
 
     public boolean isPassAsVcf() {
         return passAsVcf;
+    }
+
+    public boolean isUseSamplesInOrder() {
+        return useSamplesInOrder;
     }
 
     public int getBatchSize() {
@@ -163,6 +173,10 @@ public class ParallelImportConfig {
         this.passAsVcf = passAsVcf;
     }
 
+    public void setUseSamplesInOrder(final boolean useSamplesInOrder) {
+        this.useSamplesInOrder = useSamplesInOrder;
+    }
+
     public void setBatchSize(int batchSize) {
         this.batchSize = batchSize;
     }
@@ -175,4 +189,19 @@ public class ParallelImportConfig {
         this.mergedHeader = mergedHeader;
     }
 
+    public String getOutputCallsetmapJsonFile() {
+        return outputCallsetMapJsonFile;
+    }
+
+    public String getOutputVidmapJsonFile() {
+        return outputVidMapJsonFile;
+    }
+
+    public void setOutputCallsetmapJsonFile(final String outputCallsetMapJsonFile) {
+        this.outputCallsetMapJsonFile = outputCallsetMapJsonFile;
+    }
+
+    public void setOutputVidmapJsonFile(final String outputVidMapJsonFile) {
+        this.outputVidMapJsonFile = outputVidMapJsonFile;
+    }
 }

--- a/src/main/java/com/intel/genomicsdb/reader/ChrArrayFolderComparator.java
+++ b/src/main/java/com/intel/genomicsdb/reader/ChrArrayFolderComparator.java
@@ -2,6 +2,8 @@ package com.intel.genomicsdb.reader;
 
 import java.util.Comparator;
 
+import static com.intel.genomicsdb.Constants.CHROMOSOME_FOLDER_DELIMITER_SYMBOL_REGEX;
+
 public class ChrArrayFolderComparator implements Comparator<String> {
     @Override
     public int compare(String o1, String o2) {
@@ -14,12 +16,12 @@ public class ChrArrayFolderComparator implements Comparator<String> {
     }
 
     private String extractChromsomeName(String s) {
-        String[] values = s.split("#");
+        String[] values = s.split(CHROMOSOME_FOLDER_DELIMITER_SYMBOL_REGEX);
         return values[0];
     }
 
     private int extractIntervalStart(String s) {
-        String[] values = s.split("#");
+        String[] values = s.split(CHROMOSOME_FOLDER_DELIMITER_SYMBOL_REGEX);
         return Integer.parseInt(values[1]);
     }
 }

--- a/src/main/java/com/intel/genomicsdb/reader/ChrArrayFolderComparator.java
+++ b/src/main/java/com/intel/genomicsdb/reader/ChrArrayFolderComparator.java
@@ -1,0 +1,25 @@
+package com.intel.genomicsdb.reader;
+
+import java.util.Comparator;
+
+public class ChrArrayFolderComparator implements Comparator<String> {
+    @Override
+    public int compare(String o1, String o2) {
+        int chromCompare = extractChromsomeName(o1).compareTo(extractChromsomeName(o2));
+        if (chromCompare == 0) {
+            return extractIntervalStart(o1) - extractIntervalStart(o2);
+        } else {
+            return chromCompare;
+        }
+    }
+
+    private String extractChromsomeName(String s) {
+        String[] values = s.split("#");
+        return values[0];
+    }
+
+    private int extractIntervalStart(String s) {
+        String[] values = s.split("#");
+        return Integer.parseInt(values[1]);
+    }
+}

--- a/src/main/java/com/intel/genomicsdb/reader/GenomicsDBFeatureIterator.java
+++ b/src/main/java/com/intel/genomicsdb/reader/GenomicsDBFeatureIterator.java
@@ -107,9 +107,11 @@ public class GenomicsDBFeatureIterator<T extends Feature, SOURCE> implements Clo
             return genomicsDBQueryStream;
         }).map(gqs -> this.codec.makeSourceFromStream(gqs)).collect(Collectors.toList());
         if (sources.isEmpty()) throw new IllegalStateException("There are no sources based on those query parameters");
+        if (!readAsBCF) { //VCF Codec must parse out header again since getHeaderEnd() returns 0
+          for(SOURCE currSource : this.sources)
+            this.codec.readHeader(currSource); //no need to store header anywhere
+        }
         this.currentSource = this.sources.get(0);
-        if (!readAsBCF) //VCF Codec must parse out header again since getHeaderEnd() returns 0
-            this.codec.readHeader(this.currentSource); //no need to store header anywhere
         this.timer = new GenomicsDBTimer();
         this.closedBefore = false;
     }

--- a/src/main/java/com/intel/genomicsdb/reader/GenomicsDBFeatureIterator.java
+++ b/src/main/java/com/intel/genomicsdb/reader/GenomicsDBFeatureIterator.java
@@ -125,7 +125,10 @@ public class GenomicsDBFeatureIterator<T extends Feature, SOURCE> implements Clo
 
     @Override
     public boolean hasNext() {
-        if (this.codec.isDone(this.currentSource)) setNextSourceAsCurrent();
+        int index = 0;
+        //While loop since the next source might not return any data, but subsequent sources might
+        while(this.codec.isDone(this.currentSource) && index < this.sources.size())
+          index = setNextSourceAsCurrent();
         boolean isDone = (this.codec.isDone(this.currentSource));
         if (isDone) close();
         return !isDone;
@@ -163,8 +166,10 @@ public class GenomicsDBFeatureIterator<T extends Feature, SOURCE> implements Clo
         throw new UnsupportedOperationException("Remove is not supported in Iterators");
     }
 
-    private void setNextSourceAsCurrent() {
+    private int setNextSourceAsCurrent() {
+        this.codec.close(this.currentSource);
         int index = this.sources.indexOf(this.currentSource);
         if (index < this.sources.size() - 1) this.currentSource = this.sources.get(index + 1);
+        return index + 1;
     }
 }

--- a/src/main/java/com/intel/genomicsdb/reader/GenomicsDBFeatureReader.java
+++ b/src/main/java/com/intel/genomicsdb/reader/GenomicsDBFeatureReader.java
@@ -154,9 +154,10 @@ public class GenomicsDBFeatureReader<T extends Feature, SOURCE> implements Featu
     }
 
     private List<String> resolveChromosomeArrayFolderList() {
-        String[] chromosomeIntervalArraysNames = getArrayListFromWorkspace(new File(exportConfiguration.getWorkspace()));
-        List<String> qjfs = createArrayFolderListFromArrayStream(Arrays.stream(chromosomeIntervalArraysNames));
-        List<Coordinates.ContigInterval> contigIntervals = Arrays.stream(chromosomeIntervalArraysNames).map(name -> {
+        List<String> chromosomeIntervalArraysNames = Arrays.asList(getArrayListFromWorkspace(new File(exportConfiguration.getWorkspace())));
+        chromosomeIntervalArraysNames.sort(new ChrArrayFolderComparator());
+        List<String> qjfs = createArrayFolderListFromArrayStream(chromosomeIntervalArraysNames.stream());
+        List<Coordinates.ContigInterval> contigIntervals = chromosomeIntervalArraysNames.stream().map(name -> {
             String[] ref = name.split("#");
             throwExceptionIfArrayFolderRefIsWrong(ref);
             return Coordinates.ContigInterval.newBuilder().setContig(ref[0]).setBegin(Integer.parseInt(ref[1]))

--- a/src/main/java/com/intel/genomicsdb/reader/GenomicsDBFeatureReader.java
+++ b/src/main/java/com/intel/genomicsdb/reader/GenomicsDBFeatureReader.java
@@ -178,8 +178,13 @@ public class GenomicsDBFeatureReader<T extends Feature, SOURCE> implements Featu
     }
 
     private String createQueryJsonFileFromArrayFolderName(String folderName) throws IOException {
-        GenomicsDBExportConfiguration.ExportConfiguration fullExportConfiguration =
-                GenomicsDBExportConfiguration.ExportConfiguration.newBuilder(this.exportConfiguration).setArrayName(folderName).build();
+        GenomicsDBExportConfiguration.ExportConfiguration.Builder fullExportConfigurationBuilder =
+            GenomicsDBExportConfiguration.ExportConfiguration.newBuilder(this.exportConfiguration)
+            .setArrayName(folderName);
+        if(this.exportConfiguration.getQueryColumnRangesCount() == 0
+                && this.exportConfiguration.getQueryRowRangesCount() == 0)
+            fullExportConfigurationBuilder.setScanFull(true);
+        GenomicsDBExportConfiguration.ExportConfiguration fullExportConfiguration = fullExportConfigurationBuilder.build();
         return createTempQueryJsonFile(fullExportConfiguration.getArrayName(), fullExportConfiguration).getAbsolutePath();
     }
 

--- a/src/main/java/com/intel/genomicsdb/reader/GenomicsDBFeatureReader.java
+++ b/src/main/java/com/intel/genomicsdb/reader/GenomicsDBFeatureReader.java
@@ -179,8 +179,7 @@ public class GenomicsDBFeatureReader<T extends Feature, SOURCE> implements Featu
         Stream<String> stream = Arrays.stream(chromosomeIntervalArraysNames).filter(name -> {
             String[] ref = name.split("#");
             throwExceptionIfArrayFolderRefIsWrong(ref);
-            return chromosome.equals(ref[0]) && ((intervalStart >= Integer.parseInt(ref[1]) && intervalStart <= Integer.parseInt(ref[2])) ||
-                    (intervalEnd >= Integer.parseInt(ref[1]) && intervalEnd <= Integer.parseInt(ref[2])));
+            return chromosome.equals(ref[0]) && (intervalStart <= Integer.parseInt(ref[2]) && intervalEnd >= Integer.parseInt(ref[1]));
         });
         return createArrayFolderListFromArrayStream(stream);
     }

--- a/src/main/java/com/intel/genomicsdb/reader/GenomicsDBFeatureReader.java
+++ b/src/main/java/com/intel/genomicsdb/reader/GenomicsDBFeatureReader.java
@@ -67,8 +67,8 @@ public class GenomicsDBFeatureReader<T extends Feature, SOURCE> implements Featu
         this.exportConfiguration = exportConfiguration;
         this.codec = codec;
         this.loaderJSONFile = loaderJSONFile.orElse("");
-        String[] chromosomeIntervalArrays = this.exportConfiguration.hasArray() ? new String[]{
-                exportConfiguration.getArray()
+        String[] chromosomeIntervalArrays = this.exportConfiguration.hasArrayName() ? new String[]{
+                exportConfiguration.getArrayName()
         } : getArrayListFromWorkspace(new File(exportConfiguration.getWorkspace()));
         if (chromosomeIntervalArrays == null || chromosomeIntervalArrays.length < 1)
             throw new IllegalStateException("There is no genome data stored in the database");
@@ -124,9 +124,9 @@ public class GenomicsDBFeatureReader<T extends Feature, SOURCE> implements Featu
         List<String> chromosomeIntervalArraysPaths =
                 (this.queryJsonFileName != null && !this.queryJsonFileName.isEmpty())
                         ? Collections.singletonList(this.queryJsonFileName)
-                        : this.exportConfiguration.hasArray() ? createArrayFolderListFromArrayStream(
+                        : this.exportConfiguration.hasArrayName() ? createArrayFolderListFromArrayStream(
                         new ArrayList<String>() {{
-                            add(exportConfiguration.getArray());
+                            add(exportConfiguration.getArrayName());
                         }}.stream()) : resolveChromosomeArrayFolderList();
         return new GenomicsDBFeatureIterator(this.loaderJSONFile, chromosomeIntervalArraysPaths,
                 this.featureCodecHeader, this.codec, Optional.of(this.intervalsPerArray));
@@ -145,9 +145,9 @@ public class GenomicsDBFeatureReader<T extends Feature, SOURCE> implements Featu
         List<String> chromosomeIntervalArraysPaths =
                 (this.queryJsonFileName != null && !this.queryJsonFileName.isEmpty())
                         ? Collections.singletonList(this.queryJsonFileName)
-                        : this.exportConfiguration.hasArray() ? createArrayFolderListFromArrayStream(
+                        : this.exportConfiguration.hasArrayName() ? createArrayFolderListFromArrayStream(
                         new ArrayList<String>() {{
-                            add(exportConfiguration.getArray());
+                            add(exportConfiguration.getArrayName());
                         }}.stream()) : resolveChromosomeArrayFolderList(chr, start, end);
         return new GenomicsDBFeatureIterator(this.loaderJSONFile, chromosomeIntervalArraysPaths, this.featureCodecHeader,
                 this.codec, chr, start, end, Optional.empty());
@@ -192,9 +192,9 @@ public class GenomicsDBFeatureReader<T extends Feature, SOURCE> implements Featu
     private List<String> createArrayFolderListFromArrayStream(Stream<String> stream) {
         return stream.map(name -> {
             GenomicsDBExportConfiguration.ExportConfiguration fullExportConfiguration =
-                    GenomicsDBExportConfiguration.ExportConfiguration.newBuilder(this.exportConfiguration).setArray(name).build();
+                    GenomicsDBExportConfiguration.ExportConfiguration.newBuilder(this.exportConfiguration).setArrayName(name).build();
             try {
-                return createTempQueryJsonFile(fullExportConfiguration.getArray(), fullExportConfiguration).getAbsolutePath();
+                return createTempQueryJsonFile(fullExportConfiguration.getArrayName(), fullExportConfiguration).getAbsolutePath();
             } catch (IOException ex) {
                 throw new RuntimeException(ex);
             }
@@ -204,7 +204,7 @@ public class GenomicsDBFeatureReader<T extends Feature, SOURCE> implements Featu
     private void generateHeadersForQuery(final String randomExistingArrayName) throws IOException {
         GenomicsDBExportConfiguration.ExportConfiguration fullExportConfiguration =
                 GenomicsDBExportConfiguration.ExportConfiguration.newBuilder(this.exportConfiguration)
-                        .setArray(randomExistingArrayName).build();
+                        .setArrayName(randomExistingArrayName).build();
         File queryJSONFile = createTempQueryJsonFile(randomExistingArrayName, fullExportConfiguration);
         generateHeadersForQueryGivenQueryJSONFile(queryJSONFile.getAbsolutePath());
         queryJSONFile.delete();

--- a/src/main/java/com/intel/genomicsdb/reader/GenomicsDBFeatureReader.java
+++ b/src/main/java/com/intel/genomicsdb/reader/GenomicsDBFeatureReader.java
@@ -168,8 +168,9 @@ public class GenomicsDBFeatureReader<T extends Feature, SOURCE> implements Featu
                     .setEnd(Integer.parseInt(ref[2])).build();
         }).collect(toList());
         this.intervalsPerArray = contigIntervals.stream().map(contig -> {
-            List<String> qjf = qjfs.stream().filter(file -> file.contains(String.format(CHROMOSOME_INTERVAL_FOLDER,
-                    contig.getContig(), contig.getBegin(), contig.getEnd()))).collect(toList());
+            List<String> qjf = qjfs.stream().filter(file -> file.contains(String.format("_%s",
+                    String.format(CHROMOSOME_INTERVAL_FOLDER, contig.getContig(), contig.getBegin(), contig.getEnd()))
+            )).collect(toList());
             if (qjf.size() != 1) {
                 throw new IllegalStateException("Multiple results for relation array folder name <-> contig interval values");
             }

--- a/src/resources/CMakeLists.txt
+++ b/src/resources/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(PROTOBUF_PROTO_FILES
+    genomicsdb_coordinates.proto
     genomicsdb_callsets_mapping.proto
     genomicsdb_export_config.proto
     genomicsdb_import_config.proto
@@ -10,6 +11,7 @@ if(PROTOBUF_REGENERATE)
         CACHE INTERNAL "Path to protocol buffers generated C++ headers")
     add_custom_target(PROTOBUF_GENERATED_CXX_TARGET DEPENDS ${PROTOBUF_GENERATED_CXX_SRCS} ${PROTOBUF_GENERATED_CXX_HDRS})
     set(PROTOBUF_GENERATED_JAVA_SRCS
+      ${GENOMICSDB_MAVEN_BUILD_DIR}/protobuf/com/intel/genomicsdb/GenomicsDBColumn.java
         ${GENOMICSDB_MAVEN_BUILD_DIR}/protobuf/com/intel/genomicsdb/GenomicsDBCallsetsMapProto.java
         ${GENOMICSDB_MAVEN_BUILD_DIR}/protobuf/com/intel/genomicsdb/GenomicsDBExportConfiguration.java
         ${GENOMICSDB_MAVEN_BUILD_DIR}/protobuf/com/intel/genomicsdb/GenomicsDBImportConfiguration.java

--- a/src/resources/genomicsdb_coordinates.proto
+++ b/src/resources/genomicsdb_coordinates.proto
@@ -1,0 +1,63 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2016-2018 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of 
+ * this software and associated documentation files (the "Software"), to deal in 
+ * the Software without restriction, including without limitation the rights to 
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of 
+ * the Software, and to permit persons to whom the Software is furnished to do so, 
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all 
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS 
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+syntax = "proto2";
+
+option java_package = "com.intel.genomicsdb.model";
+option java_outer_classname = "coordinates";
+
+message ContigPosition {
+  required string contig = 1;
+  required int64 position = 2;
+}
+
+message GenomicsDBColumn {
+  oneof column {
+    int64 tiledb_column = 1;
+    ContigPosition contig_position = 2;
+  }
+}
+
+message TileDBColumnInterval {
+  required int64 begin = 1;
+  required int64 end = 2;
+}
+
+message ContigInterval {
+  required string contig = 1;
+  required int64 begin = 2;
+  required int64 end = 3;
+}
+
+message GenomicsDBColumnInterval {
+  oneof interval {
+    TileDBColumnInterval column_interval = 1;
+    ContigInterval contig_interval = 2;
+  }
+}
+
+message GenomicsDBColumnOrInterval {
+  oneof column_or_interval {
+    GenomicsDBColumn column = 1;
+    GenomicsDBColumnInterval column_interval = 2;
+  }
+}

--- a/src/resources/genomicsdb_coordinates.proto
+++ b/src/resources/genomicsdb_coordinates.proto
@@ -23,7 +23,7 @@
 syntax = "proto2";
 
 option java_package = "com.intel.genomicsdb.model";
-option java_outer_classname = "coordinates";
+option java_outer_classname = "Coordinates";
 
 message ContigPosition {
   required string contig = 1;

--- a/src/resources/genomicsdb_export_config.proto
+++ b/src/resources/genomicsdb_export_config.proto
@@ -47,7 +47,10 @@ message RowRangeList {
 
 message ExportConfiguration {
   required string workspace = 1;
-  optional string array = 2;
+  oneof array {
+    string array_name = 2;
+    bool generate_array_name_from_partition_bounds = 18;
+  }
   required string reference_genome = 3;
   repeated GenomicsDBColumnOrIntervalList query_column_ranges = 4;
   repeated RowRangeList query_row_ranges = 5;
@@ -63,5 +66,5 @@ message ExportConfiguration {
   optional bool produce_FILTER_field = 15;
   optional bool sites_only_query = 16;
   optional bool produce_GT_with_min_PL_value_for_spanning_deletions = 17;
-  optional bool scan_full = 18;
+  optional bool scan_full = 19;
 }

--- a/src/resources/genomicsdb_export_config.proto
+++ b/src/resources/genomicsdb_export_config.proto
@@ -27,16 +27,13 @@
 
 syntax = "proto2";
 
+import "genomicsdb_coordinates.proto";
+
 option java_package = "com.intel.genomicsdb.model";
 option java_outer_classname = "GenomicsDBExportConfiguration";
 
-message ColumnRange {
-  required int64 low = 1;
-  required int64 high = 2;
-}
-
-message ColumnRangeList {
-  repeated ColumnRange range_list = 1;
+message GenomicsDBColumnOrIntervalList {
+  repeated GenomicsDBColumnOrInterval column_or_interval_list = 1;
 }
 
 message RowRange {
@@ -52,7 +49,7 @@ message ExportConfiguration {
   required string workspace = 1;
   optional string array = 2;
   required string reference_genome = 3;
-  repeated ColumnRangeList query_column_ranges = 4;
+  repeated GenomicsDBColumnOrIntervalList query_column_ranges = 4;
   repeated RowRangeList query_row_ranges = 5;
   repeated string attributes = 6;
   optional string vcf_header_filename = 7;

--- a/src/resources/genomicsdb_import_config.proto
+++ b/src/resources/genomicsdb_import_config.proto
@@ -40,9 +40,12 @@ import "genomicsdb_coordinates.proto";
 message Partition {
   required GenomicsDBColumn begin = 1;
   optional string workspace = 2;
-  optional string array = 3 [default = "genomicsdb_array"];
-  optional string vcf_output_filename = 4;
-  optional GenomicsDBColumn end = 5;
+  oneof array {
+    string array_name = 3;
+    bool generate_array_name_from_partition_bounds = 4;
+  }
+  optional string vcf_output_filename = 5;
+  optional GenomicsDBColumn end = 6;
 }
 
 message ImportConfiguration {

--- a/src/resources/genomicsdb_import_config.proto
+++ b/src/resources/genomicsdb_import_config.proto
@@ -35,23 +35,25 @@ syntax = "proto2";
 option java_package = "com.intel.genomicsdb.model";
 option java_outer_classname = "GenomicsDBImportConfiguration";
 
+import "genomicsdb_coordinates.proto";
 
 message Partition {
-  required int64 begin = 1;
+  required GenomicsDBColumn begin = 1;
   optional string workspace = 2;
   optional string array = 3 [default = "genomicsdb_array"];
   optional string vcf_output_filename = 4;
-  optional int64 end = 5 [default = 0x7FFFFFFFFFFFFFFF ];
+  optional GenomicsDBColumn end = 5;
 }
-
+/*
 message GATK4Integration {
   optional string output_vidmap_json_file = 1;
   optional string output_callsetmap_json_file = 2;
   optional int32 batch_size = 3 [default = 0];
   optional bool use_samples_in_order_provided = 4 [default = false];
-  optional int64 lower_sample_index = 5 [default = 0];
-  optional int64 upper_sample_index = 6 [default = 0x7FFFFFFFFFFFFFFF];
+  optional bool validate_sample_to_reader_map = 5 [default = false];
+  optional bool pass_as_vcf = 6 [default = true];
 }
+*/
 
 message ImportConfiguration {
   required int64 size_per_column_partition = 7 [default = 16384];
@@ -71,9 +73,10 @@ message ImportConfiguration {
   optional bool compress_tiledb_array = 15 [default = true];
   optional int64 num_cells_per_tile = 16 [default = 1000];
   optional bool fail_if_updating = 17 [default = false];
-  optional GATK4Integration gatk4_integration_parameters = 18;
   optional int32 tiledb_compression_level = 19 [default = -1];
   optional bool consolidate_tiledb_array_after_load = 20 [default = false];
   optional bool disable_synced_writes = 21 [default = true];
   optional bool ignore_cells_not_in_partition = 22;
+  optional int64 lb_callset_row_idx = 23 [ default = 0 ];
+  optional int64 ub_callset_row_idx = 24 [ default = 0x7FFFFFFFFFFFFFFF ];
 }

--- a/src/resources/genomicsdb_import_config.proto
+++ b/src/resources/genomicsdb_import_config.proto
@@ -44,16 +44,6 @@ message Partition {
   optional string vcf_output_filename = 4;
   optional GenomicsDBColumn end = 5;
 }
-/*
-message GATK4Integration {
-  optional string output_vidmap_json_file = 1;
-  optional string output_callsetmap_json_file = 2;
-  optional int32 batch_size = 3 [default = 0];
-  optional bool use_samples_in_order_provided = 4 [default = false];
-  optional bool validate_sample_to_reader_map = 5 [default = false];
-  optional bool pass_as_vcf = 6 [default = true];
-}
-*/
 
 message ImportConfiguration {
   required int64 size_per_column_partition = 7 [default = 16384];

--- a/src/test/java/com/intel/genomicsdb/importer/GenomicsDBImporterSpec.java
+++ b/src/test/java/com/intel/genomicsdb/importer/GenomicsDBImporterSpec.java
@@ -23,11 +23,9 @@
 package com.intel.genomicsdb.importer;
 
 import com.intel.genomicsdb.GenomicsDBTestUtils;
-import com.intel.genomicsdb.importer.GenomicsDBImporter;
 import com.intel.genomicsdb.importer.extensions.CallSetMapExtensions;
 import com.intel.genomicsdb.importer.model.ChromosomeInterval;
 import com.intel.genomicsdb.model.*;
-import com.intel.genomicsdb.model.GenomicsDBImportConfiguration.ImportConfiguration;
 import com.intel.genomicsdb.reader.GenomicsDBFeatureReader;
 import htsjdk.tribble.CloseableTribbleIterator;
 import htsjdk.tribble.FeatureReader;
@@ -51,7 +49,6 @@ import java.io.IOException;
 import java.util.*;
 import java.util.Optional;
 
-import static com.intel.genomicsdb.importer.Constants.DEFAULT_ZERO_BATCH_SIZE;
 
 public final class GenomicsDBImporterSpec implements CallSetMapExtensions {
     private static final String TEST_CHROMOSOME_NAME = "1";
@@ -68,10 +65,7 @@ public final class GenomicsDBImporterSpec implements CallSetMapExtensions {
         GenomicsDBCallsetsMapProto.CallsetMappingPB callsetMappingPB =
                 this.generateSortedCallSetMap(sampleToReaderMap, true, false);
 
-        //Set<VCFHeaderLine> mergedHeader = createMergedHeader(sampleToReaderMap);
-
         GenomicsDBImporter importer = getGenomicsDBImporterForMultipleImport();
-                //getGenomicsDBImporterForSingleImport(sampleToReaderMap, mergedHeader);
 
         importer.executeImport();
 
@@ -82,170 +76,179 @@ public final class GenomicsDBImporterSpec implements CallSetMapExtensions {
         Assert.assertTrue(callsetFile.exists());
     }
 
-//    @Test(testName = "genomicsdb importer outputs merged headers as a JSON file",
-//            dataProvider = "vcfFiles",
-//            dataProviderClass = GenomicsDBTestUtils.class)
-//    public void testVidMapJSONOutput(Map<String, FeatureReader<VariantContext>> sampleToReaderMap)
-//            throws IOException, InterruptedException {
-//        GenomicsDBCallsetsMapProto.CallsetMappingPB callsetMappingPB_A =
-//                this.generateSortedCallSetMap(sampleToReaderMap, true, false);
-//
-//        Set<VCFHeaderLine> mergedHeader = createMergedHeader(sampleToReaderMap);
-//
-//        GenomicsDBImporter importer = getGenomicsDBImporterForSingleImport(sampleToReaderMap, mergedHeader);
-//
-//        importer.writeVidMapJSONFile(tempVidJsonFile.getAbsolutePath(),
-//                importer.generateVidMapFromMergedHeader(mergedHeader));
-//        importer.writeVcfHeaderFile(tempVcfHeaderFile.getAbsolutePath(), mergedHeader);
-//        importer.writeCallsetMapJSONFile(tempCallsetJsonFile.getAbsolutePath(),
-//                callsetMappingPB_A);
-//        importer.executeSingleImport();
-//
-//        Assert.assertEquals(importer.isDone(), true);
-//        Assert.assertEquals(tempVidJsonFile.isFile(), true);
-//        Assert.assertEquals(tempCallsetJsonFile.isFile(), true);
-//        Assert.assertEquals(tempVcfHeaderFile.isFile(), true);
-//
-//        JSONParser parser = new JSONParser();
-//
-//        try {
-//            FileReader fileReader = new FileReader(tempCallsetJsonFile.getAbsolutePath());
-//            JSONObject jsonObject = (JSONObject) parser.parse(fileReader);
-//            JSONArray callsetArray = (JSONArray) jsonObject.get("callsets");
-//
-//            int index = 0;
-//
-//            for (Object cObject : callsetArray) {
-//                JSONObject sampleObject = (JSONObject) cObject;
-//                String sampleName_B = (String) sampleObject.get("sample_name");
-//                Long tiledbRowIndex_B = (Long) sampleObject.get("row_idx");
-//                String stream_name_B = (String) sampleObject.get("stream_name");
-//
-//                String sampleName_A = callsetMappingPB_A.getCallsets(index).getSampleName();
-//                Long tileDBRowIndex_A = callsetMappingPB_A.getCallsets(index).getRowIdx();
-//                String stream_name_A = callsetMappingPB_A.getCallsets(index).getStreamName();
-//
-//                Assert.assertEquals(sampleName_A, sampleName_B);
-//                Assert.assertEquals(tileDBRowIndex_A, tiledbRowIndex_B);
-//                Assert.assertEquals(stream_name_A, stream_name_B);
-//                index++;
-//            }
-//        } catch (ParseException p) {
-//            p.printStackTrace();
-//        }
-//    }
-//
-//    @Test(testName = "genomicsdb importer with null feature readers",
-//            dataProvider = "nullFeatureReaders",
-//            dataProviderClass = GenomicsDBTestUtils.class,
-//            expectedExceptions = IllegalArgumentException.class)
-//    public void testNullFeatureReaders(Map<String, FeatureReader<VariantContext>> sampleToReaderMap)
-//            throws IOException {
-//
-//        new ChromosomeInterval(TEST_CHROMOSOME_NAME, 1, 249250619);
-//
-//        this.generateSortedCallSetMap(sampleToReaderMap, true, false);
-//    }
-//
-//    @Test(testName = "should run parallel import with multiple chromosome intervals and one GVCF")
-//    public void testShouldRunParallelImportWithMultipleChromosomeIntervalsAndOneGvcf() throws IOException, InterruptedException {
-//        //Given
-//        GenomicsDBImporter importer = getGenomicsDBImporterForMultipleImport();
-//
-//        //When
-//        importer.executeImport();
-//
-//        //Then
-//        Assert.assertEquals(tempVidJsonFile.isFile(), true);
-//        Assert.assertEquals(tempCallsetJsonFile.isFile(), true);
-//
-//        String referenceGenome = "tests/inputs/chr1_10MB.fasta.gz";
-//        GenomicsDBExportConfiguration.ColumnRangeList.Builder columnRange = GenomicsDBExportConfiguration.ColumnRangeList.newBuilder()
-//                .addRangeList(GenomicsDBExportConfiguration.ColumnRange.newBuilder().setHigh(50000).setLow(0));
-//        GenomicsDBExportConfiguration.RowRangeList.Builder rowRange = GenomicsDBExportConfiguration.RowRangeList.newBuilder()
-//                .addRangeList(GenomicsDBExportConfiguration.RowRange.newBuilder().setHigh(3).setLow(0));
-//
-//        GenomicsDBExportConfiguration.ExportConfiguration exportConfiguration = GenomicsDBExportConfiguration.ExportConfiguration.newBuilder()
-//                .setWorkspace(WORKSPACE.getAbsolutePath()).setReferenceGenome(referenceGenome)
-//                .setVidMappingFile(tempVidJsonFile.getAbsolutePath())
-//                .setCallsetMappingFile(tempCallsetJsonFile.getAbsolutePath()).setProduceGTField(true)
-//                .setScanFull(true)
-//                .addQueryColumnRanges(columnRange)
-//                .addQueryRowRanges(rowRange)
-//                .addAttributes("GT")
-//                .build();
-//
-//        GenomicsDBFeatureReader reader = new GenomicsDBFeatureReader<>(exportConfiguration, new BCF2Codec(), Optional.empty());
-//
-//        CloseableTribbleIterator<VariantContext> gdbIterator = reader.iterator();
-//        List<VariantContext> varCtxList = new ArrayList<>();
-//        while (gdbIterator.hasNext()) varCtxList.add(gdbIterator.next());
-//
-//        assert(varCtxList.size() == 2);
-//        assert(varCtxList.get(0).getStart() == 12141);
-//        assert(varCtxList.get(1).getStart() == 17385);
-//    }
-//
-//    @Test(testName = "should be able to query using specific array name")
-//    public void testShouldBeAbleToQueryUsingSpecificArrayName() throws IOException, InterruptedException {
-//        //Given
-//        GenomicsDBImporter importer = getGenomicsDBImporterForMultipleImport();
-//        importer.executeImport();
-//        Assert.assertEquals(tempVidJsonFile.isFile(), true);
-//        Assert.assertEquals(tempCallsetJsonFile.isFile(), true);
-//        String referenceGenome = "tests/inputs/chr1_10MB.fasta.gz";
-//
-//        //When
-//        GenomicsDBExportConfiguration.ExportConfiguration exportConfiguration = GenomicsDBExportConfiguration.ExportConfiguration.newBuilder()
-//                .setWorkspace(WORKSPACE.getAbsolutePath())
-//                .setReferenceGenome(referenceGenome)
-//                .setVidMappingFile(tempVidJsonFile.getAbsolutePath())
-//                .setCallsetMappingFile(tempCallsetJsonFile.getAbsolutePath()).setProduceGTField(true)
-//                .setScanFull(true)
-//                .setArray("1#17000#18000")
-//                .build();
-//
-//        GenomicsDBFeatureReader reader = new GenomicsDBFeatureReader<>(exportConfiguration, new BCF2Codec(), Optional.empty());
-//
-//        CloseableTribbleIterator<VariantContext> gdbIterator = reader.iterator();
-//        List<VariantContext> varCtxList = new ArrayList<>();
-//        while (gdbIterator.hasNext()) varCtxList.add(gdbIterator.next());
-//
-//        //Then
-//        assert(varCtxList.size() == 1);
-//        assert(varCtxList.get(0).getStart() == 17385);
-//    }
-//
-//    @Test(testName = "should be able to query using specific chromosome interval")
-//    public void testShouldBeAbleToQueryUsingSpecificChromosomeInterval() throws IOException, InterruptedException {
-//        //Given
-//        GenomicsDBImporter importer = getGenomicsDBImporterForMultipleImport();
-//        importer.executeImport();
-//        Assert.assertEquals(tempVidJsonFile.isFile(), true);
-//        Assert.assertEquals(tempCallsetJsonFile.isFile(), true);
-//
-//        //When
-//        String referenceGenome = "tests/inputs/chr1_10MB.fasta.gz";
-//
-//        GenomicsDBExportConfiguration.ExportConfiguration exportConfiguration = GenomicsDBExportConfiguration.ExportConfiguration.newBuilder()
-//                .setWorkspace(WORKSPACE.getAbsolutePath())
-//                .setReferenceGenome(referenceGenome)
-//                .setVidMappingFile(tempVidJsonFile.getAbsolutePath())
-//                .setCallsetMappingFile(tempCallsetJsonFile.getAbsolutePath())
-//                .setProduceGTField(true)
-//                .setScanFull(true)
-//                .build();
-//
-//        GenomicsDBFeatureReader reader = new GenomicsDBFeatureReader<>(exportConfiguration, new BCF2Codec(), Optional.empty());
-//
-//        CloseableTribbleIterator<VariantContext> gdbIterator = reader.query("1", 17000, 18000);
-//        List<VariantContext> varCtxList = new ArrayList<>();
-//        while (gdbIterator.hasNext()) varCtxList.add(gdbIterator.next());
-//
-//        //Then
-//        assert(varCtxList.size() == 1);
-//        assert(varCtxList.get(0).getStart() == 17385);
-//    }
+    @Test(testName = "genomicsdb importer outputs merged headers as a JSON file",
+            dataProvider = "vcfFiles",
+            dataProviderClass = GenomicsDBTestUtils.class)
+    public void testVidMapJSONOutput(Map<String, FeatureReader<VariantContext>> sampleToReaderMap)
+            throws IOException, InterruptedException {
+        GenomicsDBCallsetsMapProto.CallsetMappingPB callsetMappingPB_A =
+                this.generateSortedCallSetMap(sampleToReaderMap, true, false);
+
+        Set<VCFHeaderLine> mergedHeader = createMergedHeader(sampleToReaderMap);
+
+        GenomicsDBImporter importer = getGenomicsDBImporterForMultipleImport();
+
+        importer.writeVidMapJSONFile(tempVidJsonFile.getAbsolutePath(),
+                importer.generateVidMapFromMergedHeader(mergedHeader));
+        importer.writeVcfHeaderFile(tempVcfHeaderFile.getAbsolutePath(), mergedHeader);
+        importer.writeCallsetMapJSONFile(tempCallsetJsonFile.getAbsolutePath(),
+                callsetMappingPB_A);
+        importer.executeImport();
+
+        Assert.assertEquals(importer.isDone(), true);
+        Assert.assertEquals(tempVidJsonFile.isFile(), true);
+        Assert.assertEquals(tempCallsetJsonFile.isFile(), true);
+        Assert.assertEquals(tempVcfHeaderFile.isFile(), true);
+
+        JSONParser parser = new JSONParser();
+
+        try {
+            FileReader fileReader = new FileReader(tempCallsetJsonFile.getAbsolutePath());
+            JSONObject jsonObject = (JSONObject) parser.parse(fileReader);
+            JSONArray callsetArray = (JSONArray) jsonObject.get("callsets");
+
+            int index = 0;
+
+            for (Object cObject : callsetArray) {
+                JSONObject sampleObject = (JSONObject) cObject;
+                String sampleName_B = (String) sampleObject.get("sample_name");
+                Long tiledbRowIndex_B = (Long) sampleObject.get("row_idx");
+                String stream_name_B = (String) sampleObject.get("stream_name");
+
+                String sampleName_A = callsetMappingPB_A.getCallsets(index).getSampleName();
+                Long tileDBRowIndex_A = callsetMappingPB_A.getCallsets(index).getRowIdx();
+                String stream_name_A = callsetMappingPB_A.getCallsets(index).getStreamName();
+
+                Assert.assertEquals(sampleName_A, sampleName_B);
+                Assert.assertEquals(tileDBRowIndex_A, tiledbRowIndex_B);
+                Assert.assertEquals(stream_name_A, stream_name_B);
+                index++;
+            }
+        } catch (ParseException p) {
+            p.printStackTrace();
+        }
+    }
+
+    @Test(testName = "genomicsdb importer with null feature readers",
+            dataProvider = "nullFeatureReaders",
+            dataProviderClass = GenomicsDBTestUtils.class,
+            expectedExceptions = IllegalArgumentException.class)
+    public void testNullFeatureReaders(Map<String, FeatureReader<VariantContext>> sampleToReaderMap)
+            throws IOException {
+
+        new ChromosomeInterval(TEST_CHROMOSOME_NAME, 1, 249250619);
+
+        this.generateSortedCallSetMap(sampleToReaderMap, true, false);
+    }
+
+    @Test(testName = "should run parallel import with multiple chromosome intervals and one GVCF")
+    public void testShouldRunParallelImportWithMultipleChromosomeIntervalsAndOneGvcf() throws IOException, InterruptedException {
+        //Given
+        GenomicsDBImporter importer = getGenomicsDBImporterForMultipleImport();
+
+        //When
+        importer.executeImport();
+
+        //Then
+        Assert.assertEquals(tempVidJsonFile.isFile(), true);
+        Assert.assertEquals(tempCallsetJsonFile.isFile(), true);
+
+        String referenceGenome = "tests/inputs/chr1_10MB.fasta.gz";
+
+        Coordinates.ContigInterval interval0 = Coordinates.ContigInterval.newBuilder().setBegin(0).setEnd(50000).setContig("").build();
+        Coordinates.GenomicsDBColumnInterval columnInterval = Coordinates.GenomicsDBColumnInterval.newBuilder()
+                .setContigInterval(interval0).build();
+        Coordinates.GenomicsDBColumnOrInterval columnRange = Coordinates.GenomicsDBColumnOrInterval.newBuilder()
+                .setColumnInterval(columnInterval).build();
+        List<Coordinates.GenomicsDBColumnOrInterval> columnRangeLists = new ArrayList<>(2);
+        columnRangeLists.add(columnRange);
+        GenomicsDBExportConfiguration.GenomicsDBColumnOrIntervalList columnRanges =
+                GenomicsDBExportConfiguration.GenomicsDBColumnOrIntervalList.newBuilder()
+                        .addAllColumnOrIntervalList(columnRangeLists).build();
+        GenomicsDBExportConfiguration.RowRangeList.Builder rowRange = GenomicsDBExportConfiguration.RowRangeList.newBuilder()
+                .addRangeList(GenomicsDBExportConfiguration.RowRange.newBuilder().setHigh(3).setLow(0));
+
+        GenomicsDBExportConfiguration.ExportConfiguration exportConfiguration = GenomicsDBExportConfiguration.ExportConfiguration.newBuilder()
+                .setWorkspace(WORKSPACE.getAbsolutePath()).setReferenceGenome(referenceGenome)
+                .setVidMappingFile(tempVidJsonFile.getAbsolutePath())
+                .setCallsetMappingFile(tempCallsetJsonFile.getAbsolutePath()).setProduceGTField(true)
+                .setScanFull(true)
+                .addQueryColumnRanges(columnRanges)
+                .addQueryRowRanges(rowRange)
+                .addAttributes("GT")
+                .build();
+
+        GenomicsDBFeatureReader reader = new GenomicsDBFeatureReader<>(exportConfiguration, new BCF2Codec(), Optional.empty());
+
+        CloseableTribbleIterator<VariantContext> gdbIterator = reader.iterator();
+        List<VariantContext> varCtxList = new ArrayList<>();
+        while (gdbIterator.hasNext()) varCtxList.add(gdbIterator.next());
+
+        assert(varCtxList.size() == 2);
+        assert(varCtxList.get(0).getStart() == 12141);
+        assert(varCtxList.get(1).getStart() == 17385);
+    }
+
+    @Test(testName = "should be able to query using specific array name")
+    public void testShouldBeAbleToQueryUsingSpecificArrayName() throws IOException, InterruptedException {
+        //Given
+        GenomicsDBImporter importer = getGenomicsDBImporterForMultipleImport();
+        importer.executeImport();
+        Assert.assertEquals(tempVidJsonFile.isFile(), true);
+        Assert.assertEquals(tempCallsetJsonFile.isFile(), true);
+        String referenceGenome = "tests/inputs/chr1_10MB.fasta.gz";
+
+        //When
+        GenomicsDBExportConfiguration.ExportConfiguration exportConfiguration = GenomicsDBExportConfiguration.ExportConfiguration.newBuilder()
+                .setWorkspace(WORKSPACE.getAbsolutePath())
+                .setReferenceGenome(referenceGenome)
+                .setVidMappingFile(tempVidJsonFile.getAbsolutePath())
+                .setCallsetMappingFile(tempCallsetJsonFile.getAbsolutePath()).setProduceGTField(true)
+                .setScanFull(true)
+                .setArray("1#17000#18000")
+                .build();
+
+        GenomicsDBFeatureReader reader = new GenomicsDBFeatureReader<>(exportConfiguration, new BCF2Codec(), Optional.empty());
+
+        CloseableTribbleIterator<VariantContext> gdbIterator = reader.iterator();
+        List<VariantContext> varCtxList = new ArrayList<>();
+        while (gdbIterator.hasNext()) varCtxList.add(gdbIterator.next());
+
+        //Then
+        assert(varCtxList.size() == 1);
+        assert(varCtxList.get(0).getStart() == 17385);
+    }
+
+    @Test(testName = "should be able to query using specific chromosome interval")
+    public void testShouldBeAbleToQueryUsingSpecificChromosomeInterval() throws IOException, InterruptedException {
+        //Given
+        GenomicsDBImporter importer = getGenomicsDBImporterForMultipleImport();
+        importer.executeImport();
+        Assert.assertEquals(tempVidJsonFile.isFile(), true);
+        Assert.assertEquals(tempCallsetJsonFile.isFile(), true);
+
+        //When
+        String referenceGenome = "tests/inputs/chr1_10MB.fasta.gz";
+
+        GenomicsDBExportConfiguration.ExportConfiguration exportConfiguration = GenomicsDBExportConfiguration.ExportConfiguration.newBuilder()
+                .setWorkspace(WORKSPACE.getAbsolutePath())
+                .setReferenceGenome(referenceGenome)
+                .setVidMappingFile(tempVidJsonFile.getAbsolutePath())
+                .setCallsetMappingFile(tempCallsetJsonFile.getAbsolutePath())
+                .setProduceGTField(true)
+                .setScanFull(true)
+                .build();
+
+        GenomicsDBFeatureReader reader = new GenomicsDBFeatureReader<>(exportConfiguration, new BCF2Codec(), Optional.empty());
+
+        CloseableTribbleIterator<VariantContext> gdbIterator = reader.query("1", 17000, 18000);
+        List<VariantContext> varCtxList = new ArrayList<>();
+        while (gdbIterator.hasNext()) varCtxList.add(gdbIterator.next());
+
+        //Then
+        assert(varCtxList.size() == 1);
+        assert(varCtxList.get(0).getStart() == 17385);
+    }
 
     @BeforeMethod
     public void cleanUpBefore() throws IOException {
@@ -268,25 +271,6 @@ public final class GenomicsDBImporterSpec implements CallSetMapExtensions {
         }
         return VCFUtils.smartMergeHeaders(headers, true);
     }
-
-//    private GenomicsDBImporter getGenomicsDBImporterForSingleImport(
-//            Map<String, FeatureReader<VariantContext>> sampleToReaderMap, Set<VCFHeaderLine> mergedHeader) throws IOException {
-//        ChromosomeInterval chromosomeInterval =
-//                new ChromosomeInterval(TEST_CHROMOSOME_NAME, 1, 249250619);
-//        GenomicsDBImportConfiguration.Partition partition = GenomicsDBImportConfiguration.Partition.newBuilder()
-//                .setBegin(0).setWorkspace(WORKSPACE.getAbsolutePath()).setArray(TEST_CHROMOSOME_NAME).build();
-//        ImportConfiguration importConfiguration =
-//                ImportConfiguration.newBuilder().addColumnPartitions(partition)
-//                        .setSizePerColumnPartition(1024L).setSegmentSize(10000000L).build();
-//        return new GenomicsDBImporter(
-//                sampleToReaderMap,
-//                mergedHeader,
-//                chromosomeInterval,
-//                importConfiguration,
-//                DEFAULT_ZERO_BATCH_SIZE,
-//                true,
-//                true);
-//    }
 
     private GenomicsDBImporter getGenomicsDBImporterForMultipleImport() throws FileNotFoundException {
         String[] args = ("-L 1:12000-13000 -L 1:17000-18000 " +

--- a/src/test/java/com/intel/genomicsdb/importer/GenomicsDBImporterSpec.java
+++ b/src/test/java/com/intel/genomicsdb/importer/GenomicsDBImporterSpec.java
@@ -205,7 +205,7 @@ public final class GenomicsDBImporterSpec implements CallSetMapExtensions {
                 .setVidMappingFile(tempVidJsonFile.getAbsolutePath())
                 .setCallsetMappingFile(tempCallsetJsonFile.getAbsolutePath()).setProduceGTField(true)
                 .setScanFull(true)
-                .setArray("1#17000#18000")
+                .setArrayName("1#17000#18000")
                 .build();
 
         GenomicsDBFeatureReader reader = new GenomicsDBFeatureReader<>(exportConfiguration, new BCF2Codec(), Optional.empty());

--- a/src/test/java/com/intel/genomicsdb/importer/GenomicsDBImporterSpec.java
+++ b/src/test/java/com/intel/genomicsdb/importer/GenomicsDBImporterSpec.java
@@ -49,6 +49,8 @@ import java.io.IOException;
 import java.util.*;
 import java.util.Optional;
 
+import static com.intel.genomicsdb.Constants.CHROMOSOME_INTERVAL_FOLDER;
+
 
 public final class GenomicsDBImporterSpec implements CallSetMapExtensions {
     private static final String TEST_CHROMOSOME_NAME = "1";
@@ -205,7 +207,7 @@ public final class GenomicsDBImporterSpec implements CallSetMapExtensions {
                 .setVidMappingFile(tempVidJsonFile.getAbsolutePath())
                 .setCallsetMappingFile(tempCallsetJsonFile.getAbsolutePath()).setProduceGTField(true)
                 .setScanFull(true)
-                .setArrayName("1#17000#18000")
+                .setArrayName(String.format(CHROMOSOME_INTERVAL_FOLDER, "1", 17000, 18000))
                 .build();
 
         GenomicsDBFeatureReader reader = new GenomicsDBFeatureReader<>(exportConfiguration, new BCF2Codec(), Optional.empty());

--- a/src/test/java/com/intel/genomicsdb/model/GenomicsDBExportConfigurationSpec.java
+++ b/src/test/java/com/intel/genomicsdb/model/GenomicsDBExportConfigurationSpec.java
@@ -21,7 +21,6 @@
  */
 package com.intel.genomicsdb.model;
 
-import com.intel.genomicsdb.model.GenomicsDBExportConfiguration;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -36,7 +35,9 @@ public class GenomicsDBExportConfigurationSpec {
   private final String REFERENCE_GENOME = "/path/to/HG38.fasta";
   private final String TEST_VIDMAP_FILENAME = "/path/to/junk/vidmap.json";
   private final String TEST_CALLSETMAP_FILENAME = "/path/to/junk/callsetmap.json";
-  private final List<String> ATTRIBUTES = new ArrayList<>(Arrays.asList("REF", "ALT", "BaseQRankSum", "MQ", "RAW_MQ", "MQ0", "ClippingRankSum", "MQRankSum", "ReadPosRankSum", "DP", "GT", "GQ", "SB", "AD", "PL", "DP_FORMAT", "MIN_DP", "PID", "PGT"));
+  private final List<String> ATTRIBUTES = new ArrayList<>(Arrays.asList("REF", "ALT", "BaseQRankSum", "MQ",
+          "RAW_MQ", "MQ0", "ClippingRankSum", "MQRankSum", "ReadPosRankSum", "DP", "GT", "GQ", "SB", "AD", "PL",
+          "DP_FORMAT", "MIN_DP", "PID", "PGT"));
 
   private final String VCF_HEADER_FILENAME = "inputs/template_vcf_header.vcf";
   private final String VCF_OUTPUT_FILENAME = "outputs/test.vcf.gz";
@@ -46,111 +47,51 @@ public class GenomicsDBExportConfigurationSpec {
 
   @Test(groups = {"configuration tests"})
   public void testExportConfiguration() {
-    List<GenomicsDBExportConfiguration.ColumnRange> columnRanges0 = new ArrayList<>(2);
-    List<GenomicsDBExportConfiguration.ColumnRange> columnRanges1 = new ArrayList<>(2);
-    List<GenomicsDBExportConfiguration.ColumnRangeList> columnRangeLists = new ArrayList<>(2);
     List<GenomicsDBExportConfiguration.RowRange> rowRanges0 = new ArrayList<>(2);
     List<GenomicsDBExportConfiguration.RowRange> rowRanges1 = new ArrayList<>(2);
     List<GenomicsDBExportConfiguration.RowRangeList> rowRangeLists = new ArrayList<>(2);
 
+    Coordinates.ContigInterval interval0 = Coordinates.ContigInterval.newBuilder().setBegin(0).setEnd(100000).setContig("").build();
+    Coordinates.ContigInterval interval1 = Coordinates.ContigInterval.newBuilder().setBegin(100001).setEnd(200000).setContig("").build();
+    Coordinates.GenomicsDBColumnInterval columnInterval0 = Coordinates.GenomicsDBColumnInterval.newBuilder()
+            .setContigInterval(interval0).setContigInterval(interval1).build();
+    Coordinates.GenomicsDBColumnOrInterval columnRanges0 = Coordinates.GenomicsDBColumnOrInterval.newBuilder()
+            .setColumnInterval(columnInterval0).build();
 
-    GenomicsDBExportConfiguration.ColumnRange.Builder columnRange0 =
-      GenomicsDBExportConfiguration.ColumnRange.newBuilder();
-    GenomicsDBExportConfiguration.ColumnRange c0 =
-      columnRange0
-        .setLow(0)
-        .setHigh(100000)
-        .build();
+    Coordinates.ContigInterval interval2 = Coordinates.ContigInterval.newBuilder().setBegin(200001).setEnd(300000).setContig("").build();
+    Coordinates.GenomicsDBColumnInterval columnInterval1 = Coordinates.GenomicsDBColumnInterval.newBuilder()
+            .setContigInterval(interval1).setContigInterval(interval2).build();
+    Coordinates.GenomicsDBColumnOrInterval columnRanges1 = Coordinates.GenomicsDBColumnOrInterval.newBuilder()
+            .setColumnInterval(columnInterval1).build();
+
+  List<Coordinates.GenomicsDBColumnOrInterval> columnRangeLists = new ArrayList<>(2);
+  columnRangeLists.add(columnRanges0);
+  columnRangeLists.add(columnRanges1);
+
+  GenomicsDBExportConfiguration.GenomicsDBColumnOrIntervalList list =
+          GenomicsDBExportConfiguration.GenomicsDBColumnOrIntervalList.newBuilder()
+                  .addAllColumnOrIntervalList(columnRangeLists).build();
+
+
+    GenomicsDBExportConfiguration.RowRange.Builder rowRange0 = GenomicsDBExportConfiguration.RowRange.newBuilder();
+    GenomicsDBExportConfiguration.RowRange r0 = rowRange0.setLow(0).setHigh(100).build();
     
-    GenomicsDBExportConfiguration.ColumnRange.Builder columnRange1 =
-      GenomicsDBExportConfiguration.ColumnRange.newBuilder();
-    GenomicsDBExportConfiguration.ColumnRange c1 =
-      columnRange1
-        .setLow(100001)
-        .setHigh(200000)
-        .build();
-
-    columnRanges0.add(c0);
-    columnRanges0.add(c1); 
-
-    GenomicsDBExportConfiguration.ColumnRange.Builder columnRange2 =
-      GenomicsDBExportConfiguration.ColumnRange.newBuilder();
-    GenomicsDBExportConfiguration.ColumnRange c2 =
-      columnRange2
-        .setLow(200001)
-        .setHigh(300000)
-        .build();
-    
-    GenomicsDBExportConfiguration.ColumnRange.Builder columnRange3 =
-      GenomicsDBExportConfiguration.ColumnRange.newBuilder();
-    GenomicsDBExportConfiguration.ColumnRange c3 =
-      columnRange3
-        .setLow(300001)
-        .setHigh(400000)
-        .build();
-
-    columnRanges1.add(c2);
-    columnRanges1.add(c3); 
-
-    GenomicsDBExportConfiguration.ColumnRangeList.Builder columnRangeList0 =
-      GenomicsDBExportConfiguration.ColumnRangeList.newBuilder();
-
-    GenomicsDBExportConfiguration.ColumnRangeList queryColumnRanges0 =
-      columnRangeList0
-        .addAllRangeList(columnRanges0)
-        .build();
-
-    GenomicsDBExportConfiguration.ColumnRangeList.Builder columnRangeList1 =
-      GenomicsDBExportConfiguration.ColumnRangeList.newBuilder();
-
-    GenomicsDBExportConfiguration.ColumnRangeList queryColumnRanges1 =
-      columnRangeList1
-        .addAllRangeList(columnRanges1)
-        .build();
-
-    columnRangeLists.add(queryColumnRanges0);
-    columnRangeLists.add(queryColumnRanges1);
-
-    GenomicsDBExportConfiguration.RowRange.Builder rowRange0 =
-      GenomicsDBExportConfiguration.RowRange.newBuilder();
-    GenomicsDBExportConfiguration.RowRange r0 =
-      rowRange0
-        .setLow(0)
-        .setHigh(100)
-        .build();
-    
-    GenomicsDBExportConfiguration.RowRange.Builder rowRange1 =
-      GenomicsDBExportConfiguration.RowRange.newBuilder();
-    GenomicsDBExportConfiguration.RowRange r1 =
-      rowRange1
-        .setLow(101)
-        .setHigh(200)
-        .build();
+    GenomicsDBExportConfiguration.RowRange.Builder rowRange1 = GenomicsDBExportConfiguration.RowRange.newBuilder();
+    GenomicsDBExportConfiguration.RowRange r1 = rowRange1.setLow(101).setHigh(200).build();
 
     rowRanges0.add(r0);
     rowRanges0.add(r1); 
 
-    GenomicsDBExportConfiguration.RowRange.Builder rowRange2 =
-      GenomicsDBExportConfiguration.RowRange.newBuilder();
-    GenomicsDBExportConfiguration.RowRange r2 =
-      rowRange2
-        .setLow(201)
-        .setHigh(300)
-        .build();
+    GenomicsDBExportConfiguration.RowRange.Builder rowRange2 = GenomicsDBExportConfiguration.RowRange.newBuilder();
+    GenomicsDBExportConfiguration.RowRange r2 = rowRange2.setLow(201).setHigh(300).build();
     
-    GenomicsDBExportConfiguration.RowRange.Builder rowRange3 =
-      GenomicsDBExportConfiguration.RowRange.newBuilder();
-    GenomicsDBExportConfiguration.RowRange r3 =
-      rowRange3
-        .setLow(301)
-        .setHigh(400)
-        .build();
+    GenomicsDBExportConfiguration.RowRange.Builder rowRange3 = GenomicsDBExportConfiguration.RowRange.newBuilder();
+    GenomicsDBExportConfiguration.RowRange r3 = rowRange3.setLow(301).setHigh(400).build();
 
     rowRanges1.add(r2);
     rowRanges1.add(r3); 
 
-    GenomicsDBExportConfiguration.RowRangeList.Builder rowRangeList0 =
-      GenomicsDBExportConfiguration.RowRangeList.newBuilder();
+    GenomicsDBExportConfiguration.RowRangeList.Builder rowRangeList0 = GenomicsDBExportConfiguration.RowRangeList.newBuilder();
 
     GenomicsDBExportConfiguration.RowRangeList queryRowRanges0 =
       rowRangeList0
@@ -175,17 +116,17 @@ public class GenomicsDBExportConfigurationSpec {
       configBuilder
         .setWorkspace(TILEDB_WORKSPACE)
         .setArray(TEST_ARRAY)
-	.setReferenceGenome(REFERENCE_GENOME)
-        .addAllQueryColumnRanges(columnRangeLists)        
+    .setReferenceGenome(REFERENCE_GENOME)
+        .addQueryColumnRanges(list)
         .addAllQueryRowRanges(rowRangeLists)        
-	.addAllAttributes(ATTRIBUTES)
-	.setVidMappingFile(TEST_VIDMAP_FILENAME)
-	.setCallsetMappingFile(TEST_CALLSETMAP_FILENAME)
-	.setVcfHeaderFilename(VCF_HEADER_FILENAME)
-	.setVcfOutputFilename(VCF_OUTPUT_FILENAME)
-	.setVcfOutputFormat(VCF_OUTPUT_FORMAT)
-	.setMaxDiploidAltAllelesThatCanBeGenotyped(MAX_DIPLOID_ALT_ALLELES_THAT_CAN_BE_GENOTYPED)
-	.setIndexOutputVCF(INDEX_OUTPUT_VCF)
+    .addAllAttributes(ATTRIBUTES)
+    .setVidMappingFile(TEST_VIDMAP_FILENAME)
+    .setCallsetMappingFile(TEST_CALLSETMAP_FILENAME)
+    .setVcfHeaderFilename(VCF_HEADER_FILENAME)
+    .setVcfOutputFilename(VCF_OUTPUT_FILENAME)
+    .setVcfOutputFormat(VCF_OUTPUT_FORMAT)
+    .setMaxDiploidAltAllelesThatCanBeGenotyped(MAX_DIPLOID_ALT_ALLELES_THAT_CAN_BE_GENOTYPED)
+    .setIndexOutputVCF(INDEX_OUTPUT_VCF)
         .build();
     
     Assert.assertEquals(exportConfiguration.isInitialized(), true);
@@ -206,7 +147,8 @@ public class GenomicsDBExportConfigurationSpec {
     Assert.assertEquals(exportConfiguration.getWorkspace(), TILEDB_WORKSPACE);
     Assert.assertEquals(exportConfiguration.getArray(), TEST_ARRAY);
     Assert.assertEquals(exportConfiguration.getReferenceGenome(), REFERENCE_GENOME);
-    Assert.assertEquals(exportConfiguration.getQueryColumnRangesCount(), 2);
+    Assert.assertEquals(exportConfiguration.getQueryColumnRangesCount(), 1);
+
     Assert.assertEquals(exportConfiguration.getQueryRowRangesCount(), 2);
     Assert.assertEquals(exportConfiguration.getAttributesCount(), 19);
     Assert.assertEquals(exportConfiguration.getVidMappingFile(), TEST_VIDMAP_FILENAME);

--- a/src/test/java/com/intel/genomicsdb/model/GenomicsDBExportConfigurationSpec.java
+++ b/src/test/java/com/intel/genomicsdb/model/GenomicsDBExportConfigurationSpec.java
@@ -115,7 +115,7 @@ public class GenomicsDBExportConfigurationSpec {
     GenomicsDBExportConfiguration.ExportConfiguration exportConfiguration =
       configBuilder
         .setWorkspace(TILEDB_WORKSPACE)
-        .setArray(TEST_ARRAY)
+        .setArrayName(TEST_ARRAY)
     .setReferenceGenome(REFERENCE_GENOME)
         .addQueryColumnRanges(list)
         .addAllQueryRowRanges(rowRangeLists)        
@@ -133,7 +133,7 @@ public class GenomicsDBExportConfigurationSpec {
 
     // Assert has methods
     Assert.assertEquals(exportConfiguration.hasWorkspace(), true);
-    Assert.assertEquals(exportConfiguration.hasArray(), true);
+    Assert.assertEquals(exportConfiguration.hasArrayName(), true);
     Assert.assertEquals(exportConfiguration.hasReferenceGenome(), true);
     Assert.assertEquals(exportConfiguration.hasVidMappingFile(), true);
     Assert.assertEquals(exportConfiguration.hasCallsetMappingFile(), true);
@@ -145,7 +145,7 @@ public class GenomicsDBExportConfigurationSpec {
     
     // Assert gets
     Assert.assertEquals(exportConfiguration.getWorkspace(), TILEDB_WORKSPACE);
-    Assert.assertEquals(exportConfiguration.getArray(), TEST_ARRAY);
+    Assert.assertEquals(exportConfiguration.getArrayName(), TEST_ARRAY);
     Assert.assertEquals(exportConfiguration.getReferenceGenome(), REFERENCE_GENOME);
     Assert.assertEquals(exportConfiguration.getQueryColumnRangesCount(), 1);
 

--- a/src/test/java/com/intel/genomicsdb/model/GenomicsDBImportConfigurationSpec.java
+++ b/src/test/java/com/intel/genomicsdb/model/GenomicsDBImportConfigurationSpec.java
@@ -21,7 +21,6 @@
  */
 package com.intel.genomicsdb.model;
 
-import com.intel.genomicsdb.model.GenomicsDBImportConfiguration;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -33,46 +32,23 @@ public class GenomicsDBImportConfigurationSpec {
   private static final String ARRAY_FOR_PARTITION0 = "array0";
   private static final String ARRAY_FOR_PARTITION1 = "array1";
   private final String TILEDB_WORKSPACE = "/path/to/junk/folder";
-  private final String TEST_VIDMAP_FILENAME = "/path/to/junk/vidmap.json";
-  private final String TEST_CALLSETMAP_FILENAME = "/path/to/junk/callsetmap.json";
 
   @Test(groups = {"configuration tests"})
   public void testImportConfiguration() {
     List<GenomicsDBImportConfiguration.Partition> partitions = new ArrayList<>(2);
 
-    GenomicsDBImportConfiguration.Partition.Builder partition0 =
-      GenomicsDBImportConfiguration.Partition.newBuilder();
-    GenomicsDBImportConfiguration.Partition p0 =
-      partition0
-        .setBegin(0)
-        .setVcfOutputFilename("junk0")
-        .setWorkspace(TILEDB_WORKSPACE)
-        .setArray(ARRAY_FOR_PARTITION0)
-        .build();
-    GenomicsDBImportConfiguration.Partition.Builder partition1 =
-      GenomicsDBImportConfiguration.Partition.newBuilder();
-    GenomicsDBImportConfiguration.Partition p1 =
-      partition1
-        .setBegin(1000000)
-        .setVcfOutputFilename("junk1")
-        .setWorkspace(TILEDB_WORKSPACE)
-        .setArray(ARRAY_FOR_PARTITION1)
-        .build();
+    Coordinates.GenomicsDBColumn genomicsDBColumn0 = Coordinates.GenomicsDBColumn.newBuilder().setTiledbColumn(0).build();
+    GenomicsDBImportConfiguration.Partition.Builder partition0 = GenomicsDBImportConfiguration.Partition.newBuilder();
+    GenomicsDBImportConfiguration.Partition p0 = partition0.setVcfOutputFilename("junk0").setWorkspace(TILEDB_WORKSPACE)
+            .setArray(ARRAY_FOR_PARTITION0).setBegin(genomicsDBColumn0).build();
+
+    Coordinates.GenomicsDBColumn genomicsDBColumn1 = Coordinates.GenomicsDBColumn.newBuilder().setTiledbColumn(0).build();
+    GenomicsDBImportConfiguration.Partition.Builder partition1 = GenomicsDBImportConfiguration.Partition.newBuilder();
+    GenomicsDBImportConfiguration.Partition p1 = partition1.setVcfOutputFilename("junk1").setWorkspace(TILEDB_WORKSPACE)
+            .setArray(ARRAY_FOR_PARTITION1).setBegin(genomicsDBColumn1).build();
 
     partitions.add(p0);
     partitions.add(p1);
-
-    GenomicsDBImportConfiguration.GATK4Integration.Builder gBuilder =
-      GenomicsDBImportConfiguration.GATK4Integration.newBuilder();
-
-    GenomicsDBImportConfiguration.GATK4Integration integrationParameters =
-      gBuilder
-        .setBatchSize(100)
-        .setOutputVidmapJsonFile(TEST_VIDMAP_FILENAME)
-        .setOutputCallsetmapJsonFile(TEST_CALLSETMAP_FILENAME)
-        .setBatchSize(100)
-        .setUseSamplesInOrderProvided(true)
-        .build();
 
     GenomicsDBImportConfiguration.ImportConfiguration.Builder configBuilder =
       GenomicsDBImportConfiguration.ImportConfiguration.newBuilder();
@@ -86,7 +62,6 @@ public class GenomicsDBImportConfigurationSpec {
         .setRowBasedPartitioning(false)
         .addAllColumnPartitions(partitions)
         .setFailIfUpdating(false)
-        .setGatk4IntegrationParameters(integrationParameters)
         .setDisableSyncedWrites(true)
         .setIgnoreCellsNotInPartition(false)
         .build();
@@ -103,14 +78,8 @@ public class GenomicsDBImportConfigurationSpec {
     Assert.assertEquals(importConfiguration.hasProduceCombinedVcf(), false);
     Assert.assertEquals(importConfiguration.hasProduceTiledbArray(), true);
     Assert.assertEquals(importConfiguration.hasSizePerColumnPartition(), true);
-    Assert.assertEquals(importConfiguration.hasGatk4IntegrationParameters(), true);
-    Assert.assertEquals(importConfiguration.getGatk4IntegrationParameters().hasBatchSize(), true);
-    Assert.assertEquals(importConfiguration.getGatk4IntegrationParameters().hasOutputCallsetmapJsonFile(), true);
-    Assert.assertEquals(importConfiguration.getGatk4IntegrationParameters().hasOutputVidmapJsonFile(), true);
-    Assert.assertEquals(importConfiguration.getGatk4IntegrationParameters().hasUseSamplesInOrderProvided(), true);
     Assert.assertEquals(importConfiguration.hasDisableSyncedWrites(), true);
     Assert.assertEquals(importConfiguration.hasIgnoreCellsNotInPartition(), true);
-
 
     // Assert gets
     Assert.assertEquals(importConfiguration.getDoPingPongBuffering(), true);
@@ -123,6 +92,5 @@ public class GenomicsDBImportConfigurationSpec {
     Assert.assertEquals(importConfiguration.getDisableSyncedWrites(), true);
     Assert.assertEquals(importConfiguration.getIgnoreCellsNotInPartition(), false);
     Assert.assertSame(importConfiguration.getFailIfUpdating(), false);
-    Assert.assertSame(importConfiguration.getGatk4IntegrationParameters(), integrationParameters);
   }
 }

--- a/src/test/java/com/intel/genomicsdb/model/GenomicsDBImportConfigurationSpec.java
+++ b/src/test/java/com/intel/genomicsdb/model/GenomicsDBImportConfigurationSpec.java
@@ -40,12 +40,12 @@ public class GenomicsDBImportConfigurationSpec {
     Coordinates.GenomicsDBColumn genomicsDBColumn0 = Coordinates.GenomicsDBColumn.newBuilder().setTiledbColumn(0).build();
     GenomicsDBImportConfiguration.Partition.Builder partition0 = GenomicsDBImportConfiguration.Partition.newBuilder();
     GenomicsDBImportConfiguration.Partition p0 = partition0.setVcfOutputFilename("junk0").setWorkspace(TILEDB_WORKSPACE)
-            .setArray(ARRAY_FOR_PARTITION0).setBegin(genomicsDBColumn0).build();
+            .setArrayName(ARRAY_FOR_PARTITION0).setBegin(genomicsDBColumn0).build();
 
     Coordinates.GenomicsDBColumn genomicsDBColumn1 = Coordinates.GenomicsDBColumn.newBuilder().setTiledbColumn(0).build();
     GenomicsDBImportConfiguration.Partition.Builder partition1 = GenomicsDBImportConfiguration.Partition.newBuilder();
     GenomicsDBImportConfiguration.Partition p1 = partition1.setVcfOutputFilename("junk1").setWorkspace(TILEDB_WORKSPACE)
-            .setArray(ARRAY_FOR_PARTITION1).setBegin(genomicsDBColumn1).build();
+            .setArrayName(ARRAY_FOR_PARTITION1).setBegin(genomicsDBColumn1).build();
 
     partitions.add(p0);
     partitions.add(p1);

--- a/src/test/java/com/intel/genomicsdb/model/ImportConfigSpec.java
+++ b/src/test/java/com/intel/genomicsdb/model/ImportConfigSpec.java
@@ -9,7 +9,7 @@ import org.testng.annotations.Test;
 import java.nio.file.Path;
 import java.util.*;
 
-public class ParallelImportConfigSpec {
+public class ImportConfigSpec {
 
     @Test(testName = "should throw an exception when there is an intersection between chromosome intervals",
             expectedExceptions = IllegalArgumentException.class,
@@ -28,13 +28,13 @@ public class ParallelImportConfigSpec {
     public void shouldNotThrowExceptionWhenThereAreIntersectionsButDifferentChromosomes() {
         //Given
         //When
-        ParallelImportConfig config = createBaseImportConfig(false);
+        ImportConfig config = createBaseImportConfig(false);
 
         //Then
         Assert.assertEquals(config.getImportConfiguration().getColumnPartitionsList().size(), 2);
     }
 
-    private ParallelImportConfig createBaseImportConfig(final boolean withIntersection) {
+    private ImportConfig createBaseImportConfig(final boolean withIntersection) {
         String defaultName = "a";
         String secondPartition = withIntersection ? defaultName : "b";
         GenomicsDBImportConfiguration.ImportConfiguration configuration = GenomicsDBImportConfiguration.ImportConfiguration.newBuilder()
@@ -64,10 +64,10 @@ public class ParallelImportConfigSpec {
         int batchSize = 1000;
         Set<VCFHeaderLine> mergedHeader = new HashSet();
         Map<String, Path> sampleNameToVcfPath = new TreeMap<>();
-        ParallelImportConfig.Func<Map<String, Path>, Integer, Integer,
+        ImportConfig.Func<Map<String, Path>, Integer, Integer,
                 Map<String, FeatureReader<VariantContext>>> sampleToReaderMap = (a, b, c) -> new TreeMap<>();
 
-        return new ParallelImportConfig(configuration, validateSampleToReaderMap, passAsVcf, batchSize, mergedHeader,
+        return new ImportConfig(configuration, validateSampleToReaderMap, passAsVcf, batchSize, mergedHeader,
                 sampleNameToVcfPath, sampleToReaderMap);
     }
 }

--- a/src/test/java/com/intel/genomicsdb/reader/ChrArrayFolderComparatorSpec.java
+++ b/src/test/java/com/intel/genomicsdb/reader/ChrArrayFolderComparatorSpec.java
@@ -1,0 +1,27 @@
+package com.intel.genomicsdb.reader;
+
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ChrArrayFolderComparatorSpec {
+    @Test(testName = "should compare first by chromosome and then interval start")
+    public void shouldCompareFirstByChromosomeAndThenIntervalStart() {
+        //Given
+        List<String> arrayList = new ArrayList<>();
+        arrayList.add("1#100#200");
+        arrayList.add("1#201#300");
+        arrayList.add("2#100#200");
+        arrayList.add("2#201#300");
+        arrayList.add("1#1000#2000");
+
+        //When
+        arrayList.sort(new ChrArrayFolderComparator());
+
+        //Then
+        Assert.assertEquals(arrayList.get(2), "1#1000#2000");
+    }
+}

--- a/src/test/java/com/intel/genomicsdb/reader/ChrArrayFolderComparatorSpec.java
+++ b/src/test/java/com/intel/genomicsdb/reader/ChrArrayFolderComparatorSpec.java
@@ -7,21 +7,23 @@ import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.intel.genomicsdb.Constants.CHROMOSOME_INTERVAL_FOLDER;
+
 public class ChrArrayFolderComparatorSpec {
     @Test(testName = "should compare first by chromosome and then interval start")
     public void shouldCompareFirstByChromosomeAndThenIntervalStart() {
         //Given
         List<String> arrayList = new ArrayList<>();
-        arrayList.add("1#100#200");
-        arrayList.add("1#201#300");
-        arrayList.add("2#100#200");
-        arrayList.add("2#201#300");
-        arrayList.add("1#1000#2000");
+        arrayList.add(String.format(CHROMOSOME_INTERVAL_FOLDER, "1", 100, 200));
+        arrayList.add(String.format(CHROMOSOME_INTERVAL_FOLDER, "1", 201, 300));
+        arrayList.add(String.format(CHROMOSOME_INTERVAL_FOLDER, "2", 100, 200));
+        arrayList.add(String.format(CHROMOSOME_INTERVAL_FOLDER, "2", 201, 300));
+        arrayList.add(String.format(CHROMOSOME_INTERVAL_FOLDER, "1", 1000, 2000));
 
         //When
         arrayList.sort(new ChrArrayFolderComparator());
 
         //Then
-        Assert.assertEquals(arrayList.get(2), "1#1000#2000");
+        Assert.assertEquals(arrayList.get(2), String.format(CHROMOSOME_INTERVAL_FOLDER, "1", 1000, 2000));
     }
 }

--- a/tests/golden_outputs/java_genomicsdb_importer_from_vcfs_t0_1_2_multi_contig_vcf_0_18000
+++ b/tests/golden_outputs/java_genomicsdb_importer_from_vcfs_t0_1_2_multi_contig_vcf_0_18000
@@ -1,0 +1,125 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=PASS,Description="All filters passed">
+##ALT=<ID=NON_REF,Description="Represents any possible alternative allele at this location">
+##FILTER=<ID=LowQual,Description="Low quality">
+##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth (reads with MQ=255 or with bad mates are filtered)">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=MIN_DP,Number=1,Type=Integer,Description="Minimum DP observed within the GVCF block">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="Normalized, Phred-scaled likelihoods for genotypes as defined in the VCF specification">
+##FORMAT=<ID=SB,Number=4,Type=Integer,Description="Per-sample component statistics which comprise the Fisher's Exact Test to detect strand bias.">
+##FORMAT=<ID=PGT,Number=1,Type=String,Description="Physical phasing haplotype information, describing how the alternate alleles are phased in relation to one another">
+##FORMAT=<ID=PID,Number=1,Type=String,Description="Physical phasing ID information, where each unique ID within a given sample (but not across samples) connects records within a phasing group">
+##GATKCommandLine=<ID=HaplotypeCaller,Version=3.1-1-g07a4bf8,Date="Fri Apr 04 09:42:24 EDT 2014",Epoch=1396618944211,CommandLineOptions="analysis_type=HaplotypeCaller input_file=[/seq/external-data/1kg/GBR/exome/HG00141/HG00141.bam] showFullBamList=false read_buffer_size=null phone_home=AWS gatk_key=null tag=NA read_filter=[] intervals=[/seq/picardtemp3/seq/sample_vcf/1kg_GBR/Exome/Homo_sapiens_assembly19/7d4759a5-8e11-324c-8d3a-cc375e53e06c/scattered/temp_0001_of_10/scattered.intervals] excludeIntervals=null interval_set_rule=UNION interval_merging=ALL interval_padding=0 reference_sequence=/seq/references/Homo_sapiens_assembly19/v1/Homo_sapiens_assembly19.fasta nonDeterministicRandomSeed=false disableDithering=false maxRuntime=-1 maxRuntimeUnits=MINUTES downsampling_type=BY_SAMPLE downsample_to_fraction=null downsample_to_coverage=250 baq=OFF baqGapOpenPenalty=40.0 fix_misencoded_quality_scores=false allow_potentially_misencoded_quality_scores=false useOriginalQualities=false defaultBaseQualities=-1 performanceLog=null BQSR=null quantize_quals=0 disable_indel_quals=false emit_original_quals=false preserve_qscores_less_than=6 globalQScorePrior=-1.0 validation_strictness=SILENT remove_program_records=false keep_program_records=false sample_rename_mapping_file=null unsafe=null disable_auto_index_creation_and_locking_when_reading_rods=true num_threads=1 num_cpu_threads_per_data_thread=1 num_io_threads=0 monitorThreadEfficiency=false num_bam_file_handles=null read_group_black_list=null pedigree=[] pedigreeString=[] pedigreeValidationType=STRICT allow_intervals_with_unindexed_bam=false generateShadowBCF=false variant_index_type=LINEAR variant_index_parameter=128000 logging_level=INFO log_to_file=null help=false version=false likelihoodCalculationEngine=PairHMM heterogeneousKmerSizeResolution=COMBO_MIN graphOutput=null bamOutput=null bam_compression=null disable_bam_indexing=null generate_md5=null simplifyBAM=null bamWriterType=CALLED_HAPLOTYPES dbsnp=(RodBinding name= source=UNBOUND) dontTrimActiveRegions=false maxDiscARExtension=25 maxGGAARExtension=300 paddingAroundIndels=150 paddingAroundSNPs=20 comp=[] annotation=[ClippingRankSumTest, DepthPerSampleHC, StrandBiasBySample] excludeAnnotation=[SpanningDeletions, TandemRepeatAnnotator, ChromosomeCounts, FisherStrand, QualByDepth] heterozygosity=0.001 indel_heterozygosity=1.25E-4 genotyping_mode=DISCOVERY standard_min_confidence_threshold_for_calling=-0.0 standard_min_confidence_threshold_for_emitting=-0.0 alleles=(RodBinding name= source=UNBOUND) max_alternate_alleles=3 input_prior=[] contamination_fraction_to_filter=0.019 contamination_fraction_per_sample_file=null p_nonref_model=EXACT_INDEPENDENT exactcallslog=null kmerSize=[10, 25] dontIncreaseKmerSizesForCycles=false numPruningSamples=1 recoverDanglingHeads=false dontRecoverDanglingTails=false consensus=false emitRefConfidence=GVCF GVCFGQBands=[5, 20, 60] indelSizeToEliminateInRefModel=10 min_base_quality_score=10 minPruning=3 gcpHMM=10 includeUmappedReads=false useAllelesTrigger=false useFilteredReadsForAnnotations=false phredScaledGlobalReadMismappingRate=45 maxNumHaplotypesInPopulation=200 mergeVariantsViaLD=false pair_hmm_implementation=VECTOR_LOGLESS_CACHING keepRG=null justDetermineActiveRegions=false dontGenotype=false errorCorrectKmers=false debug=false debugGraphTransformations=false dontUseSoftClippedBases=false captureAssemblyFailureBAM=false allowCyclesInKmerGraphToGeneratePaths=false noFpga=false errorCorrectReads=false kmerLengthForReadErrorCorrection=25 minObservationsForKmerToBeSolid=20 pcr_indel_model=CONSERVATIVE activityProfileOut=null activeRegionOut=null activeRegionIn=null activeRegionExtension=null forceActive=false activeRegionMaxSize=null bandPassSigma=null min_mapping_quality_score=20 filter_reads_with_N_cigar=false filter_mismatching_base_and_quals=false filter_bases_not_stored=false">
+##GVCFBlock=minGQ=0(inclusive),maxGQ=5(exclusive)
+##GVCFBlock=minGQ=20(inclusive),maxGQ=60(exclusive)
+##GVCFBlock=minGQ=5(inclusive),maxGQ=20(exclusive)
+##GVCFBlock=minGQ=60(inclusive),maxGQ=2147483647(exclusive)
+##INFO=<ID=BaseQRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt Vs. Ref base qualities">
+##INFO=<ID=ClippingRankSum,Number=1,Type=Float,Description="Z-score From Wilcoxon rank sum test of Alt vs. Ref number of hard clipped bases">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth; some reads may have been filtered">
+##INFO=<ID=DS,Number=0,Type=Flag,Description="Were any of the samples downsampled?">
+##INFO=<ID=END,Number=1,Type=Integer,Description="Stop position of the interval">
+##INFO=<ID=HaplotypeScore,Number=1,Type=Float,Description="Consistency of the site with at most two segregating haplotypes">
+##INFO=<ID=InbreedingCoeff,Number=1,Type=Float,Description="Inbreeding coefficient as estimated from the genotype likelihoods per-sample when compared against the Hardy-Weinberg expectation">
+##INFO=<ID=MLEAC,Number=A,Type=Integer,Description="Maximum likelihood expectation (MLE) for the allele counts (not necessarily the same as the AC), for each ALT allele, in the same order as listed">
+##INFO=<ID=MLEAF,Number=A,Type=Float,Description="Maximum likelihood expectation (MLE) for the allele frequency (not necessarily the same as the AF), for each ALT allele, in the same order as listed">
+##INFO=<ID=MQ,Number=1,Type=Float,Description="RMS Mapping Quality">
+##INFO=<ID=RAW_MQ,Number=1,Type=Float,Description="Raw data for RMS Mapping Quality">
+##INFO=<ID=MQ0,Number=1,Type=Integer,Description="Total Mapping Quality Zero Reads">
+##INFO=<ID=MQRankSum,Number=1,Type=Float,Description="Z-score From Wilcoxon rank sum test of Alt vs. Ref read mapping qualities">
+##INFO=<ID=ReadPosRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt vs. Ref read position bias">
+##reference=file:///seq/references/Homo_sapiens_assembly19/v1/Homo_sapiens_assembly19.fasta
+##contig=<ID=1,length=249250621>
+##contig=<ID=2,length=243199373>
+##contig=<ID=3,length=198022430>
+##contig=<ID=4,length=191154276>
+##contig=<ID=5,length=180915260>
+##contig=<ID=6,length=171115067>
+##contig=<ID=7,length=159138663>
+##contig=<ID=8,length=146364022>
+##contig=<ID=9,length=141213431>
+##contig=<ID=10,length=135534747>
+##contig=<ID=11,length=135006516>
+##contig=<ID=12,length=133851895>
+##contig=<ID=13,length=115169878>
+##contig=<ID=14,length=107349540>
+##contig=<ID=15,length=102531392>
+##contig=<ID=16,length=90354753>
+##contig=<ID=17,length=81195210>
+##contig=<ID=18,length=78077248>
+##contig=<ID=19,length=59128983>
+##contig=<ID=20,length=63025520>
+##contig=<ID=21,length=48129895>
+##contig=<ID=22,length=51304566>
+##contig=<ID=X,length=155270560>
+##contig=<ID=Y,length=59373566>
+##contig=<ID=MT,length=16569>
+##contig=<ID=GL000207.1,length=4262>
+##contig=<ID=GL000226.1,length=15008>
+##contig=<ID=GL000229.1,length=19913>
+##contig=<ID=GL000231.1,length=27386>
+##contig=<ID=GL000210.1,length=27682>
+##contig=<ID=GL000239.1,length=33824>
+##contig=<ID=GL000235.1,length=34474>
+##contig=<ID=GL000201.1,length=36148>
+##contig=<ID=GL000247.1,length=36422>
+##contig=<ID=GL000245.1,length=36651>
+##contig=<ID=GL000197.1,length=37175>
+##contig=<ID=GL000203.1,length=37498>
+##contig=<ID=GL000246.1,length=38154>
+##contig=<ID=GL000249.1,length=38502>
+##contig=<ID=GL000196.1,length=38914>
+##contig=<ID=GL000248.1,length=39786>
+##contig=<ID=GL000244.1,length=39929>
+##contig=<ID=GL000238.1,length=39939>
+##contig=<ID=GL000202.1,length=40103>
+##contig=<ID=GL000234.1,length=40531>
+##contig=<ID=GL000232.1,length=40652>
+##contig=<ID=GL000206.1,length=41001>
+##contig=<ID=GL000240.1,length=41933>
+##contig=<ID=GL000236.1,length=41934>
+##contig=<ID=GL000241.1,length=42152>
+##contig=<ID=GL000243.1,length=43341>
+##contig=<ID=GL000242.1,length=43523>
+##contig=<ID=GL000230.1,length=43691>
+##contig=<ID=GL000237.1,length=45867>
+##contig=<ID=GL000233.1,length=45941>
+##contig=<ID=GL000204.1,length=81310>
+##contig=<ID=GL000198.1,length=90085>
+##contig=<ID=GL000208.1,length=92689>
+##contig=<ID=GL000191.1,length=106433>
+##contig=<ID=GL000227.1,length=128374>
+##contig=<ID=GL000228.1,length=129120>
+##contig=<ID=GL000214.1,length=137718>
+##contig=<ID=GL000221.1,length=155397>
+##contig=<ID=GL000209.1,length=159169>
+##contig=<ID=GL000218.1,length=161147>
+##contig=<ID=GL000220.1,length=161802>
+##contig=<ID=GL000213.1,length=164239>
+##contig=<ID=GL000211.1,length=166566>
+##contig=<ID=GL000199.1,length=169874>
+##contig=<ID=GL000217.1,length=172149>
+##contig=<ID=GL000216.1,length=172294>
+##contig=<ID=GL000215.1,length=172545>
+##contig=<ID=GL000205.1,length=174588>
+##contig=<ID=GL000219.1,length=179198>
+##contig=<ID=GL000224.1,length=179693>
+##contig=<ID=GL000223.1,length=180455>
+##contig=<ID=GL000195.1,length=182896>
+##contig=<ID=GL000212.1,length=186858>
+##contig=<ID=GL000222.1,length=186861>
+##contig=<ID=GL000200.1,length=187035>
+##contig=<ID=GL000193.1,length=189789>
+##contig=<ID=GL000194.1,length=191469>
+##contig=<ID=GL000225.1,length=211173>
+##contig=<ID=GL000192.1,length=547496>
+##contig=<ID=NC_007605,length=171823>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	HG00141	HG01958	HG01530
+1	12141	.	C	<NON_REF>	.	.	END=12144	GT:GQ:PL:MIN_DP:DP	./.:0:0,0,0:0:2	.:.:.:.:.	.:.:.:.:.
+1	12145	.	C	<NON_REF>	.	.	END=12160	GT:GQ:PL:MIN_DP:DP	./.:0:0,0,0:0:2	./.:0:0,0,0:0:3	.:.:.:.:.
+1	12161	.	C	<NON_REF>	.	.	END=12200	GT:GQ:PL:MIN_DP:DP	./.:0:0,0,0:0:2	./.:0:0,0,0:0:3	.:.:.:.:.
+1	12201	.	C	<NON_REF>	.	.	END=12277	GT:GQ:PL:MIN_DP:DP	./.:0:0,0,0:0:2	./.:0:0,0,0:0:3	.:.:.:.:.
+1	12278	.	C	<NON_REF>	.	.	END=12295	GT:GQ:PL:MIN_DP:DP	./.:0:0,0,0:0:2	.:.:.:.:.	.:.:.:.:.
+1	17385	.	G	A,T,<NON_REF>	.	.	BaseQRankSum=-2.074;ClippingRankSum=-1.859;MQRankSum=-0.432;ReadPosRankSum=0.005;MQ=31.72;RAW_MQ=8.0;MQ0=3;DP=276	GT:GQ:SB:AD:PL:PGT:PID:DP	./.:99:58,0,22,0:58,22,17,17:504,0,9807,678,1870,2548,678,1870,2548,2548:0|1:17385_G_A:80	./.:99:0,0,0,0:0,37,120,37:3336,4536,7349,358,958,0,4536,7349,958,7349:0|1:17385_G_T:120	./.:99:9,31,13,23:40,36,0,0:1018,0,1116,1137,1224,2361,1137,1224,2361,2361:.:.:76

--- a/tests/golden_outputs/java_genomicsdb_importer_from_vcfs_t0_1_2_multi_contig_vcf_12150_18000
+++ b/tests/golden_outputs/java_genomicsdb_importer_from_vcfs_t0_1_2_multi_contig_vcf_12150_18000
@@ -117,7 +117,7 @@
 ##contig=<ID=NC_007605,length=171823>
 ##reference=file:///seq/references/Homo_sapiens_assembly19/v1/Homo_sapiens_assembly19.fasta
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	HG00141	HG01958	HG01530
-1	12151	.	C	<NON_REF>	.	.	END=12160	GT:DP:GQ:MIN_DP:PL	./.:2:0:0:0,0,0	./.:3:0:0:0,0,0	.
+1	12151	.	A	<NON_REF>	.	.	END=12160	GT:DP:GQ:MIN_DP:PL	./.:2:0:0:0,0,0	./.:3:0:0:0,0,0	.
 1	12161	.	C	<NON_REF>	.	.	END=12200	GT:DP:GQ:MIN_DP:PL	./.:2:0:0:0,0,0	./.:3:0:0:0,0,0	.
 1	12201	.	C	<NON_REF>	.	.	END=12277	GT:DP:GQ:MIN_DP:PL	./.:2:0:0:0,0,0	./.:3:0:0:0,0,0	.
 1	12278	.	C	<NON_REF>	.	.	END=12295	GT:DP:GQ:MIN_DP:PL	./.:2:0:0:0,0,0	.	.

--- a/tests/golden_outputs/java_genomicsdb_importer_from_vcfs_t0_1_2_multi_contig_vcf_12150_18000
+++ b/tests/golden_outputs/java_genomicsdb_importer_from_vcfs_t0_1_2_multi_contig_vcf_12150_18000
@@ -117,8 +117,7 @@
 ##contig=<ID=NC_007605,length=171823>
 ##reference=file:///seq/references/Homo_sapiens_assembly19/v1/Homo_sapiens_assembly19.fasta
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	HG00141	HG01958	HG01530
-1	12141	.	C	<NON_REF>	.	.	END=12144	GT:DP:GQ:MIN_DP:PL	./.:2:0:0:0,0,0	.	.
-1	12145	.	C	<NON_REF>	.	.	END=12160	GT:DP:GQ:MIN_DP:PL	./.:2:0:0:0,0,0	./.:3:0:0:0,0,0	.
+1	12151	.	C	<NON_REF>	.	.	END=12160	GT:DP:GQ:MIN_DP:PL	./.:2:0:0:0,0,0	./.:3:0:0:0,0,0	.
 1	12161	.	C	<NON_REF>	.	.	END=12200	GT:DP:GQ:MIN_DP:PL	./.:2:0:0:0,0,0	./.:3:0:0:0,0,0	.
 1	12201	.	C	<NON_REF>	.	.	END=12277	GT:DP:GQ:MIN_DP:PL	./.:2:0:0:0,0,0	./.:3:0:0:0,0,0	.
 1	12278	.	C	<NON_REF>	.	.	END=12295	GT:DP:GQ:MIN_DP:PL	./.:2:0:0:0,0,0	.	.

--- a/tests/run.py
+++ b/tests/run.py
@@ -179,6 +179,24 @@ def main():
     tmpdir = tempfile.mkdtemp()
     ws_dir=tmpdir+os.path.sep+'ws';
     loader_tests = [
+            { "name" : "java_genomicsdb_importer_from_vcfs_t0_1_2_multi_contig",
+                'callset_mapping_file': 'inputs/callsets/t0_1_2.json',
+                'chromosome_intervals': [ '1:1-12160', '1:12161-12200', '1:12201-18000' ],
+                "vid_mapping_file": "inputs/vid_phased_GT.json",
+                "query_params": [
+                    { "query_column_ranges": [{
+                        "range_list": [{
+                            "low": 0,
+                            "high": 18000
+                        }]
+                    }],
+                        'callset_mapping_file': 'inputs/callsets/t0_1_2.json',
+                        "vid_mapping_file": "inputs/vid_phased_GT.json",
+                        "golden_output": {
+                        "java_vcf"   : "golden_outputs/java_genomicsdb_importer_from_vcfs_t0_1_2_multi_contig_vcf_0_18000",
+                        } }
+                ]
+            },
             { "name" : "t0_1_2", 'golden_output' : 'golden_outputs/t0_1_2_loading',
                 'callset_mapping_file': 'inputs/callsets/t0_1_2.json',
                 "query_params": [
@@ -530,7 +548,7 @@ def main():
             },
             { "name" : "java_genomicsdb_importer_from_vcfs_t0_1_2",
                 'callset_mapping_file': 'inputs/callsets/t0_1_2.json',
-                'chromosome_interval': '1:1-100000000',
+                'chromosome_intervals': [ '1:1-100000000' ],
                 "vid_mapping_file": "inputs/vid_phased_GT.json",
                 "query_params": [
                     { "query_column_ranges": [{
@@ -563,7 +581,7 @@ def main():
             },
             { "name" : "java_genomicsdb_importer_from_vcfs_t6_7_8",
                 'callset_mapping_file': 'inputs/callsets/t6_7_8.json',
-                'chromosome_interval': '1:1-100000000',
+                'chromosome_intervals': [ '1:1-100000000' ],
                 "vid_mapping_file": "inputs/vid_phased_GT.json",
                 "query_params": [
                     { "query_column_ranges": [{
@@ -629,7 +647,7 @@ def main():
             { "name" : "java_genomicsdb_importer_from_vcfs_t0_1_2_with_DS_ID",
                 'vid_mapping_file': 'inputs/vid_DS_ID_phased_GT.json',
                 'callset_mapping_file': 'inputs/callsets/t0_1_2.json',
-                'chromosome_interval': '1:1-100000000',
+                'chromosome_intervals': [ '1:1-100000000' ],
                 "query_params": [
                     { "query_column_ranges": [{
                         "range_list": [{
@@ -749,7 +767,7 @@ def main():
             { "name" : "java_genomicsdb_importer_from_vcfs_t0_1_2_all_asa",
                 'callset_mapping_file': 'inputs/callsets/t0_1_2_all_asa.json',
                 'vid_mapping_file': 'inputs/vid_all_asa.json',
-                'chromosome_interval': '1:1-100000000',
+                'chromosome_intervals': [ '1:1-100000000' ],
                 "query_params": [
                     { "query_column_ranges": [{
                         "range_list": [{
@@ -815,8 +833,10 @@ def main():
                     +' '+test_params_dict['stream_name_to_filename_mapping'],
                     shell=True, stdout=subprocess.PIPE);
         elif(test_name.find('java_genomicsdb_importer_from_vcfs') != -1):
-            arg_list = ' -L '+test_params_dict['chromosome_interval'] + ' -w ' + ws_dir \
-                    +' --use_samples_in_order ' + ' --batchsize=2 ';
+            arg_list = ''
+            for interval in test_params_dict['chromosome_intervals']:
+                arg_list += ' -L '+interval
+            arg_list += ' -w ' + ws_dir +' --use_samples_in_order ' + ' --batchsize=2 ';
             with open(test_params_dict['callset_mapping_file'], 'rb') as cs_fptr:
                 callset_mapping_dict = json.load(cs_fptr, object_pairs_hook=OrderedDict)
                 for callset_name, callset_info in callset_mapping_dict['callsets'].iteritems():

--- a/tests/run.py
+++ b/tests/run.py
@@ -195,6 +195,17 @@ def main():
                         "vid_mapping_file": "inputs/vid_phased_GT.json",
                         "golden_output": {
                         "java_vcf"   : "golden_outputs/java_genomicsdb_importer_from_vcfs_t0_1_2_multi_contig_vcf_0_18000",
+                        } },
+                    { "query_column_ranges": [{
+                        "range_list": [{
+                            "low": 12150,
+                            "high": 18000
+                        }]
+                    }],
+                        'callset_mapping_file': 'inputs/callsets/t0_1_2.json',
+                        "vid_mapping_file": "inputs/vid_phased_GT.json",
+                        "golden_output": {
+                        "java_vcf"   : "golden_outputs/java_genomicsdb_importer_from_vcfs_t0_1_2_multi_contig_vcf_12150_18000",
                         } }
                 ]
             },


### PR DESCRIPTION
Cleaned up Protobuf structures to support the following:
* A GenomicsDB column can be an int64 (TileDB column) or contig:position
* A GenomicsDB column interval can be <int64, int64> or contig:begin-end

Removed unnecessary PB structure GATK4Integration. Moved parameters lb
and ub row idx to ImportConfiguration (similar to the loader JSON).
Other parameters are irrelevant for the core library - hence, moved to
ParallelConfig.java

FIXME:
* ChromosomeInterval and ContigInterval (PB structure) are duplicates -
remove ChromosomeInterval completely