### PR TITLE
Optimization for sites only query

### DIFF
--- a/src/main/cpp/src/genomicsdb/query_variants.cc
+++ b/src/main/cpp/src/genomicsdb/query_variants.cc
@@ -290,7 +290,7 @@ void VariantQueryProcessor::finalize_queried_attributes(const VariantArraySchema
     if(queryConfig.sites_only_query())
     {
       auto FORMAT_fields_needed_in_sites_only_query = std::unordered_set<std::string>({
-          "PL", "GT", "DP_FORMAT", "MIN_DP"
+          "DP_FORMAT", "MIN_DP"
           });
       for(auto i=0ull;i<new_query_attribute_vector.size();++i)
       {


### PR DESCRIPTION
For sites-only query, no need to query PL and GT fields. Spanning deletions require PL values. However, all INFO fields are dropped for spanning deletions. Hence, the specific deletion corresponding to the spanning deletion is irrelevant for sites-only queries. So, PL and GT can be dropped from the query attributes.

Add guard if conditions in combined VCF creation code.