### PR TITLE
lb_row_idx and spanning deletion fix

### DIFF
--- a/src/main/cpp/include/genomicsdb/variant_storage_manager.h
+++ b/src/main/cpp/include/genomicsdb/variant_storage_manager.h
@@ -180,6 +180,9 @@ class VariantArrayInfo
     //Max valid row idx in array
     int64_t m_max_valid_row_idx_in_array;
     bool m_metadata_contains_max_valid_row_idx_in_array;
+    //Lb row idx
+    bool m_metadata_contains_lb_row_idx;
+    int64_t m_lb_row_idx;
     //Vid mapper
     const VidMapper* m_vid_mapper;
 #ifdef DEBUG

--- a/src/main/cpp/include/vcf/known_field_info.h
+++ b/src/main/cpp/include/vcf/known_field_info.h
@@ -211,7 +211,7 @@ class VariantUtils
     inline static bool is_deletion(const std::string& REF, const std::string& alt_allele)
     {
       auto REF_length = REF.length();
-      return (REF_length > 1u) && !IS_NON_REF_ALLELE(alt_allele) && (alt_allele.length() < REF_length);
+      return (REF_length > 1u) && !is_symbolic_allele(alt_allele) && (alt_allele.length() < REF_length);
     }
     inline static bool is_symbolic_allele(const std::string& allele)
     {

--- a/src/main/cpp/src/query_operations/broad_combined_gvcf.cc
+++ b/src/main/cpp/src/query_operations/broad_combined_gvcf.cc
@@ -904,7 +904,8 @@ void BroadCombinedGVCFOperator::handle_deletions(Variant& variant, const Variant
       auto& alt_alleles = get_known_field<VariantFieldALTData, true>(curr_call, query_config, GVCF_ALT_IDX)->get();
       assert(alt_alleles.size() > 0u);
       //Already handled as a spanning deletion, nothing to do
-      if(alt_alleles[0u] == g_vcf_SPANNING_DELETION)
+      if(alt_alleles[0u] == g_vcf_SPANNING_DELETION &&
+          (alt_alleles.size() == 1u || (alt_alleles.size() == 2u && IS_NON_REF_ALLELE(alt_alleles[1u]))))
         continue;
       m_reduced_alleles_LUT.resize_luts_if_needed(variant.get_num_calls(), alt_alleles.size()+1u); //+1 for REF
       //Reduced allele list will be REF="N", ALT="*, <NON_REF>"

--- a/src/main/cpp/src/utils/known_field_info.cc
+++ b/src/main/cpp/src/utils/known_field_info.cc
@@ -302,7 +302,7 @@ bool VariantUtils::contains_deletion(const std::string& REF, const std::vector<s
   if(REF_length <= 1u)
     return false;
   for(auto& alt_allele : ALT_vec)
-    if(!(IS_NON_REF_ALLELE(alt_allele)) && alt_allele.length() < REF_length)
+    if(!(is_symbolic_allele(alt_allele)) && alt_allele.length() < REF_length)
       return true;
   return false;
 }


### PR DESCRIPTION
* _lb_row_idx_ correctly updated in metadata for row partitions
* Spanning deletions, if present in input VCF records, correctly handled in query output. Bug fix for https://github.com/broadinstitute/gatk/issues/4716